### PR TITLE
Transition from mailgun org to gubernator-io org

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -24,8 +24,9 @@ jobs:
       - name: Fetch git tags
         run: git fetch --tags
 
-      - name: Version consistency check
-        run: ./contrib/check-version.sh
+      # TODO(thrawn01) enable after org transition is complete.
+      #- name: Version consistency check
+      #  run: ./contrib/check-version.sh
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -36,8 +36,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           tags: |
-            ghcr.io/mailgun/gubernator:${{ github.event.release.tag_name }}
-            ghcr.io/mailgun/gubernator:latest
+            ghcr.io/gubernator-io/gubernator:${{ github.event.release.tag_name }}
+            ghcr.io/gubernator-io/gubernator:latest
           build-args: |
             VERSION=${{ github.event.release.tag_name }}
           platforms: linux/amd64,linux/arm64

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,136 @@
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement by contacting
+one of the maintainers listed in the CODEOWNERS file.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+
+## Report Violations
+Please contact one of the maintainers or @thrawn01 if you wish to report a
+violation of this code of conduct or if you have a question about the adoption
+of this code of conduct.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing
+
+Thanks for your interest in contributing to Gubernator! Please take a moment to review this document **before submitting a pull request**.
+
+## Pull requests
+
+**Please ask first before starting work on any significant new features.**
+
+We love to code, and as such, we tend to code first and talk later. (wut? I haz to talk with people?) However, it's 
+never a fun experience to have your pull request declined after investing joy, time and effort into a new feature. 
+
+To avoid this from happening to you, we request that contributors create a GitHub issue and tag a maintainer, so we
+can first discuss any new feature ideas. Your ideas and suggestions are welcome!
+
+Bug requests are always welcome, but if the bug request requires a large refactor to fix, you might want to create
+and issue and discuss.
+
+### Fork and create a branch
+If this is something you think you can fix, then fork https://github.com/gubernator-io/gubernator and create
+a branch with a descriptive name.
+
+### Run tests
+You can run the test suite with all the bells and whistles by running
+```bash
+$ make test
+```
+### Run linter
+We use a linter to ensure things stay pretty, ensure your code passes the linter by running
+```bash
+$ make lint
+```
+
+### Commits & Messages
+We don't have a specific structure for commit messages, but please be as descriptive as possible and avoid
+lots of tiny commits. If this is your style, please squash before making a PR, or we may squash on merge.
+
+### Create a Pull Request
+At this point, your changes look good, and tests are passing, you are ready to create a pull request. Please
+explain WHY the PR exists in the description, and link to any related PR's or Issues.
+
+## Merging a PR (maintainers only) 
+A PR can only be merged into master by a maintainer if: CI is passing, approved by another maintainer and is
+up-to-date with the default branch. Any maintainer is allowed to merge a PR if all of these conditions ae met.
+
+## Shipping a release (maintainers only)
+See [RELEASE.md](docs/RELEASE.md) for detailed procedures
+
+
+

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ bench: ## Run Go benchmarks
 
 .PHONY: docker
 docker: ## Build Docker image
-	docker build --build-arg VERSION=$(VERSION) -t ghcr.io/mailgun/gubernator:$(VERSION) .
-	docker tag ghcr.io/mailgun/gubernator:$(VERSION) ghcr.io/mailgun/gubernator:latest
+	docker build --build-arg VERSION=$(VERSION) -t ghcr.io/gubernator-io/gubernator:$(VERSION) .
+	docker tag ghcr.io/gubernator-io/gubernator:$(VERSION) ghcr.io/gubernator-io/gubernator:latest
 
 .PHONY: build
 build: proto ## Build binary
@@ -54,7 +54,7 @@ proto: ## Build protos
 certs: ## Generate SSL certificates
 	rm certs/*.key || rm certs/*.srl || rm certs/*.csr || rm certs/*.pem || rm certs/*.cert || true
 	openssl genrsa -out certs/ca.key 4096
-	openssl req -new -x509 -key certs/ca.key -sha256 -subj "/C=US/ST=TX/O=Mailgun Technologies, Inc." -days 3650 -out certs/ca.cert
+	openssl req -new -x509 -key certs/ca.key -sha256 -subj "/C=US/ST=TX/O=Gubernator Opensource" -days 3650 -out certs/ca.cert
 	openssl genrsa -out certs/gubernator.key 4096
 	openssl req -new -key certs/gubernator.key -out certs/gubernator.csr -config certs/gubernator.conf
 	openssl x509 -req -in certs/gubernator.csr -CA certs/ca.cert -CAkey certs/ca.key -set_serial 1 -out certs/gubernator.pem -days 3650 -sha256 -extfile certs/gubernator.conf -extensions req_ext
@@ -62,8 +62,8 @@ certs: ## Generate SSL certificates
 	openssl req -new -key certs/gubernator_no_ip_san.key -out certs/gubernator_no_ip_san.csr -config certs/gubernator_no_ip_san.conf
 	openssl x509 -req -in certs/gubernator_no_ip_san.csr -CA certs/ca.cert -CAkey certs/ca.key -set_serial 2 -out certs/gubernator_no_ip_san.pem -days 3650 -sha256 -extfile certs/gubernator_no_ip_san.conf -extensions req_ext
 	# Client Auth
-	openssl req -new -x509 -days 3650 -keyout certs/client-auth-ca.key -out certs/client-auth-ca.pem -subj "/C=TX/ST=TX/O=Mailgun Technologies, Inc./CN=mailgun.com/emailAddress=admin@mailgun.com" -passout pass:test
+	openssl req -new -x509 -days 3650 -keyout certs/client-auth-ca.key -out certs/client-auth-ca.pem -subj "/C=TX/ST=TX/O=Gubernator Opensource/CN=gubernator.io/emailAddress=admin@gubernator.io" -passout pass:test
 	openssl genrsa -out certs/client-auth.key 2048
-	openssl req -sha1 -key certs/client-auth.key -new -out certs/client-auth.req -subj "/C=US/ST=TX/O=Mailgun Technologies, Inc./CN=client.com/emailAddress=admin@mailgun.com"
+	openssl req -sha1 -key certs/client-auth.key -new -out certs/client-auth.req -subj "/C=US/ST=TX/O=Gubernator Opensource/CN=client.com/emailAddress=admin@gubernator.io"
 	openssl x509 -req -days 3650 -in certs/client-auth.req -CA certs/client-auth-ca.pem -CAkey certs/client-auth-ca.key -set_serial 3 -passin pass:test -out certs/client-auth.pem
 	openssl x509 -extfile certs/client-auth.conf -extensions ssl_client -req -days 3650 -in certs/client-auth.req -CA certs/client-auth-ca.pem -CAkey certs/client-auth-ca.key -set_serial 4 -passin pass:test -out certs/client-auth.pem

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ rate limit config is made up of only 4, 64bit integers.
 ### Quick Start
 ```bash
 # Download the docker-compose file
-$ curl -O https://raw.githubusercontent.com/mailgun/gubernator/master/docker-compose.yaml
+$ curl -O https://raw.githubusercontent.com/gubernator-io/gubernator/master/docker-compose.yaml
 # Run the docker container
 $ docker-compose up -d
 ```
@@ -331,7 +331,7 @@ $ curl http://localhost:9080/v1/HealthCheck
 ##### Kubernetes
 ```bash
 # Download the kubernetes deployment spec
-$ curl -O https://raw.githubusercontent.com/mailgun/gubernator/master/k8s-deployment.yaml
+$ curl -O https://raw.githubusercontent.com/gubernator-io/gubernator/master/k8s-deployment.yaml
 
 # Edit the deployment file to change the environment config variables
 $ vi k8s-deployment.yaml

--- a/benchmark_cache_test.go
+++ b/benchmark_cache_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	gubernator "github.com/mailgun/gubernator/v2"
+	"github.com/gubernator-io/gubernator/v2"
 	"github.com/mailgun/holster/v4/clock"
 )
 

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"testing"
 
-	guber "github.com/mailgun/gubernator/v2"
-	"github.com/mailgun/gubernator/v2/cluster"
+	guber "github.com/gubernator-io/gubernator/v2"
+	"github.com/gubernator-io/gubernator/v2/cluster"
 	"github.com/mailgun/holster/v4/clock"
 	"github.com/mailgun/holster/v4/syncutil"
 	"github.com/stretchr/testify/require"

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"math/rand"
 
-	gubernator "github.com/mailgun/gubernator/v2"
+	"github.com/gubernator-io/gubernator/v2"
 	"github.com/mailgun/holster/v4/clock"
 	"github.com/mailgun/holster/v4/errors"
 	"github.com/sirupsen/logrus"

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -19,8 +19,8 @@ package cluster_test
 import (
 	"testing"
 
-	gubernator "github.com/mailgun/gubernator/v2"
-	"github.com/mailgun/gubernator/v2/cluster"
+	gubernator "github.com/gubernator-io/gubernator/v2"
+	"github.com/gubernator-io/gubernator/v2/cluster"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"

--- a/cmd/gubernator-cli/main.go
+++ b/cmd/gubernator-cli/main.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	guber "github.com/mailgun/gubernator/v2"
+	guber "github.com/gubernator-io/gubernator/v2"
 	"github.com/mailgun/holster/v4/clock"
 	"github.com/mailgun/holster/v4/errors"
 	"github.com/mailgun/holster/v4/setter"
@@ -70,7 +70,7 @@ func main() {
 	}
 	ctx := context.Background()
 	err = tracing.InitTracing(ctx,
-		"github.com/mailgun/gubernator/v2/cmd/gubernator-cli",
+		"github.com/gubernator-io/gubernator/v2/cmd/gubernator-cli",
 		tracing.WithResource(res),
 	)
 	if err != nil {

--- a/cmd/gubernator-cluster/main.go
+++ b/cmd/gubernator-cluster/main.go
@@ -21,8 +21,8 @@ import (
 	"os"
 	"os/signal"
 
-	gubernator "github.com/mailgun/gubernator/v2"
-	"github.com/mailgun/gubernator/v2/cluster"
+	"github.com/gubernator-io/gubernator/v2"
+	"github.com/gubernator-io/gubernator/v2/cluster"
 	"github.com/sirupsen/logrus"
 )
 

--- a/cmd/gubernator/main.go
+++ b/cmd/gubernator/main.go
@@ -25,7 +25,7 @@ import (
 	"runtime"
 	"syscall"
 
-	gubernator "github.com/mailgun/gubernator/v2"
+	"github.com/gubernator-io/gubernator/v2"
 	"github.com/mailgun/holster/v4/clock"
 	"github.com/mailgun/holster/v4/tracing"
 	"github.com/sirupsen/logrus"
@@ -65,7 +65,7 @@ func main() {
 	// Initialize tracing.
 	ctx := context.Background()
 	err = tracing.InitTracing(ctx,
-		"github.com/mailgun/gubernator/v2",
+		"github.com/gubernator-io/gubernator/v2",
 		tracing.WithLevel(gubernator.GetTracingLevel()),
 		tracing.WithResource(res),
 	)

--- a/cmd/healthcheck/main.go
+++ b/cmd/healthcheck/main.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 	"os"
 
-	guber "github.com/mailgun/gubernator/v2"
+	guber "github.com/gubernator-io/gubernator/v2"
 )
 
 func main() {

--- a/contrib/aws-ecs-service-discovery-deployment/README.md
+++ b/contrib/aws-ecs-service-discovery-deployment/README.md
@@ -49,15 +49,15 @@ Real gubernator would be accessible in `app.gubernator.example.com`
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| Name | Description                                                                                                        | Type | Default | Required |
+|------|--------------------------------------------------------------------------------------------------------------------|------|---------|:--------:|
 | <a name="input_dns_namespace"></a> [dns\_namespace](#input\_dns\_namespace) | The domain name the service should run. Your Gubernator instances will be available at `app.<your inputted fqdn>.` | `string` | n/a | yes |
-| <a name="input_gubernator_config"></a> [gubernator\_config](#input\_gubernator\_config) | Map of ECS Configuration for gubernator service. map(cpu, memory) | `any` | <pre>{<br>  "cpu": 256,<br>  "memory": 512<br>}</pre> | no |
-| <a name="input_gubernator_debug_mode"></a> [gubernator\_debug\_mode](#input\_gubernator\_debug\_mode) | Enable GUBER\_DEBUG env flag | `bool` | `false` | no |
-| <a name="input_gubernator_repository"></a> [gubernator\_repository](#input\_gubernator\_repository) | Gubernator Docker Repository. e.g. ghcr.io/mailgun/gubernator | `string` | n/a | yes |
-| <a name="input_gubernator_version"></a> [gubernator\_version](#input\_gubernator\_version) | Gubernator docker tag to use | `string` | n/a | yes |
-| <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix of created resources | `string` | n/a | yes |
-| <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | IPv4 CIDR Notation for VPC IP range. e.g. 10.3.0.0/16 | `string` | n/a | yes |
+| <a name="input_gubernator_config"></a> [gubernator\_config](#input\_gubernator\_config) | Map of ECS Configuration for gubernator service. map(cpu, memory)                                                  | `any` | <pre>{<br>  "cpu": 256,<br>  "memory": 512<br>}</pre> | no |
+| <a name="input_gubernator_debug_mode"></a> [gubernator\_debug\_mode](#input\_gubernator\_debug\_mode) | Enable GUBER\_DEBUG env flag                                                                                       | `bool` | `false` | no |
+| <a name="input_gubernator_repository"></a> [gubernator\_repository](#input\_gubernator\_repository) | Gubernator Docker Repository. e.g. ghcr.io/gubernator-io/gubernator                                                | `string` | n/a | yes |
+| <a name="input_gubernator_version"></a> [gubernator\_version](#input\_gubernator\_version) | Gubernator docker tag to use                                                                                       | `string` | n/a | yes |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix of created resources                                                                                        | `string` | n/a | yes |
+| <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | IPv4 CIDR Notation for VPC IP range. e.g. 10.3.0.0/16                                                              | `string` | n/a | yes |
 
 ## Outputs
 

--- a/contrib/aws-ecs-service-discovery-deployment/variables.tf
+++ b/contrib/aws-ecs-service-discovery-deployment/variables.tf
@@ -16,7 +16,7 @@ variable "dns_namespace" {
 
 variable "gubernator_repository" {
   type        = string
-  description = "Gubernator Docker Repository. e.g. ghcr.io/mailgun/gubernator"
+  description = "Gubernator Docker Repository. e.g. ghcr.io/gubernator-io/gubernator"
 }
 
 variable "gubernator_version" {

--- a/contrib/certs/gubernator.conf
+++ b/contrib/certs/gubernator.conf
@@ -7,7 +7,7 @@ distinguished_name = dn
 [dn]
 C = US
 ST = TX
-O = Mailgun Technologies, Inc.
+O = Gubernator Opensource
 CN = localhost
 [req_ext]
 subjectAltName = @alt_names

--- a/contrib/certs/gubernator_no_ip_san.conf
+++ b/contrib/certs/gubernator_no_ip_san.conf
@@ -7,7 +7,7 @@ distinguished_name = dn
 [dn]
 C = US
 ST = TX
-O = Mailgun Technologies, Inc.
+O = Gubernator Opensource
 CN = localhost
 [req_ext]
 subjectAltName = @alt_names

--- a/contrib/charts/gubernator/values.yaml
+++ b/contrib/charts/gubernator/values.yaml
@@ -13,7 +13,7 @@ gubernator:
   replicaCount: 4
 
   image:
-    repository: ghcr.io/mailgun/gubernator
+    repository: ghcr.io/gubernator-io/gubernator
     pullPolicy: IfNotPresent
 
     # By default tag is overriding appVersion from .Chart.yaml

--- a/contrib/k8s-deployment.yaml
+++ b/contrib/k8s-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       serviceAccountName: gubernator
       containers:
-        - image: ghcr.io/mailgun/gubernator:latest
+        - image: ghcr.io/gubernator-io/gubernator:latest
           imagePullPolicy: IfNotPresent
           ports:
             - name: grpc-port

--- a/docker-compose-tls.yaml
+++ b/docker-compose-tls.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   gubernator-1:
-    image: ghcr.io/mailgun/gubernator:latest
+    image: ghcr.io/gubernator-io/gubernator:latest
     entrypoint: "/gubernator"
     environment:
       # Basic member-list config
@@ -21,7 +21,7 @@ services:
       - ${PWD}/contrib/certs:/etc/tls
 
   gubernator-2:
-    image: ghcr.io/mailgun/gubernator:latest
+    image: ghcr.io/gubernator-io/gubernator:latest
     entrypoint: "/gubernator"
     environment:
       # Basic member-list config
@@ -41,7 +41,7 @@ services:
       - ${PWD}/contrib/certs:/etc/tls
 
   gubernator-3:
-    image: ghcr.io/mailgun/gubernator:latest
+    image: ghcr.io/gubernator-io/gubernator:latest
     entrypoint: "/gubernator"
     environment:
       # Basic member-list config
@@ -61,7 +61,7 @@ services:
       - ${PWD}/contrib/certs:/etc/tls
 
   gubernator-4:
-    image: ghcr.io/mailgun/gubernator:latest
+    image: ghcr.io/gubernator-io/gubernator:latest
     entrypoint: "/gubernator"
     environment:
       # Basic member-list config

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   gubernator-1:
-    image: ghcr.io/mailgun/gubernator:latest
+    image: ghcr.io/gubernator-io/gubernator:latest
     entrypoint: "/gubernator"
     environment:
       # The address GRPC requests will listen on
@@ -18,7 +18,7 @@ services:
       - "9080:80"
 
   gubernator-2:
-    image: ghcr.io/mailgun/gubernator:latest
+    image: ghcr.io/gubernator-io/gubernator:latest
     entrypoint: "/gubernator"
     environment:
       # The address GRPC requests will listen on
@@ -35,7 +35,7 @@ services:
       - "9180:80"
 
   gubernator-3:
-    image: ghcr.io/mailgun/gubernator:latest
+    image: ghcr.io/gubernator-io/gubernator:latest
     entrypoint: "/gubernator"
     environment:
       # The address GRPC requests will listen on
@@ -52,7 +52,7 @@ services:
       - "9280:80"
 
   gubernator-4:
-    image: ghcr.io/mailgun/gubernator:latest
+    image: ghcr.io/gubernator-io/gubernator:latest
     entrypoint: "/gubernator"
     environment:
       - GUBER_DEBUG=true

--- a/functional_test.go
+++ b/functional_test.go
@@ -31,9 +31,9 @@ import (
 	"testing"
 	"time"
 
+	guber "github.com/gubernator-io/gubernator/v2"
+	"github.com/gubernator-io/gubernator/v2/cluster"
 	"github.com/mailgun/errors"
-	guber "github.com/mailgun/gubernator/v2"
-	"github.com/mailgun/gubernator/v2/cluster"
 	"github.com/mailgun/holster/v4/clock"
 	"github.com/mailgun/holster/v4/syncutil"
 	"github.com/mailgun/holster/v4/testutil"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mailgun/gubernator/v2
+module github.com/gubernator-io/gubernator/v2
 
 go 1.20
 

--- a/interval_test.go
+++ b/interval_test.go
@@ -19,7 +19,7 @@ package gubernator_test
 import (
 	"testing"
 
-	gubernator "github.com/mailgun/gubernator/v2"
+	"github.com/gubernator-io/gubernator/v2"
 	"github.com/mailgun/holster/v4/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/lrucache_test.go
+++ b/lrucache_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	gubernator "github.com/mailgun/gubernator/v2"
+	"github.com/gubernator-io/gubernator/v2"
 	"github.com/mailgun/holster/v4/clock"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"

--- a/metadata_carrier_test.go
+++ b/metadata_carrier_test.go
@@ -19,7 +19,7 @@ package gubernator_test
 import (
 	"testing"
 
-	gubernator "github.com/mailgun/gubernator/v2"
+	"github.com/gubernator-io/gubernator/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/mock_cache_test.go
+++ b/mock_cache_test.go
@@ -19,7 +19,7 @@ package gubernator_test
 // Mock implementation of Cache.
 
 import (
-	guber "github.com/mailgun/gubernator/v2"
+	guber "github.com/gubernator-io/gubernator/v2"
 	"github.com/stretchr/testify/mock"
 )
 

--- a/mock_loader_test.go
+++ b/mock_loader_test.go
@@ -19,7 +19,7 @@ package gubernator_test
 // Mock implementation of Loader.
 
 import (
-	guber "github.com/mailgun/gubernator/v2"
+	guber "github.com/gubernator-io/gubernator/v2"
 	"github.com/stretchr/testify/mock"
 )
 

--- a/mock_store_test.go
+++ b/mock_store_test.go
@@ -21,7 +21,7 @@ package gubernator_test
 import (
 	"context"
 
-	guber "github.com/mailgun/gubernator/v2"
+	guber "github.com/gubernator-io/gubernator/v2"
 	"github.com/stretchr/testify/mock"
 )
 

--- a/peer_client_test.go
+++ b/peer_client_test.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"testing"
 
-	gubernator "github.com/mailgun/gubernator/v2"
-	"github.com/mailgun/gubernator/v2/cluster"
+	"github.com/gubernator-io/gubernator/v2"
+	"github.com/gubernator-io/gubernator/v2/cluster"
 	"github.com/mailgun/holster/v4/clock"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"

--- a/python/setup.py
+++ b/python/setup.py
@@ -39,7 +39,7 @@ setup(
     description="Python client for gubernator",
     author="Derrick J. Wippler",
     author_email='thrawn01@gmail.com',
-    url='https://github.com/mailgun/gubernator',
+    url='https://github.com/gubernator-io/gubernator',
     package_dir={'': '.'},
     packages=find_packages('.', exclude=['tests']),
     install_requires=requirements,

--- a/store_test.go
+++ b/store_test.go
@@ -22,7 +22,7 @@ import (
 	"net"
 	"testing"
 
-	gubernator "github.com/mailgun/gubernator/v2"
+	"github.com/gubernator-io/gubernator/v2"
 	"github.com/mailgun/holster/v4/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/tls.go
+++ b/tls.go
@@ -269,8 +269,7 @@ func SetupTLS(conf *TLSConfig) error {
 		}
 
 		// error if neither was provided
-		//nolint:staticcheck // ignoring tlsCert.RootCAs.Subjects is deprecated because cert does not come from SystemCertPool.
-		if len(clientPool.Subjects()) == 0 {
+		if len(clientPool.Subjects()) == 0 { //nolint:all
 			return errors.New("client auth enabled, but no CA's provided")
 		}
 

--- a/tls_test.go
+++ b/tls_test.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"testing"
 
-	gubernator "github.com/mailgun/gubernator/v2"
+	"github.com/gubernator-io/gubernator/v2"
 	"github.com/mailgun/holster/v4/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/workers_internal_test.go
+++ b/workers_internal_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018-2022 Mailgun Technologies Inc
+Copyright 2024 Mailgun Technologies Inc
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/workers_test.go
+++ b/workers_test.go
@@ -22,7 +22,7 @@ import (
 	"sort"
 	"testing"
 
-	guber "github.com/mailgun/gubernator/v2"
+	guber "github.com/gubernator-io/gubernator/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
### Purpose
This is to transition the repo from github.com/mailgun/gubernator to github.com/gubernator-io/gubernator such that adding and removing contributors is simplified and does not require maintainers have access to the mailgun org.

### Implementation
* Transition public container from `ghcr.io/mailgun/gubernator` to `ghcr.io/gubernator-io/gubernator`
* Rename all import paths from `github.com/mailgun/gubernator` to `github.com/gubernator-io/gubernator`
*Ensure links to all external and github resources point to `https://raw.githubusercontent.com/gubernator-io/gubernator/master`
* Added `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`

### Manual Process
- [x] Ensure existing tags remain
- [x] Transition old container tags to new repo
- [x] Ensure github actions work as expected
- [ ] Create a new release in `github.com/gubernator-io/gubernator` which refers to the old repo release log
- [ ] Validate docker containers for the new release are built and can be accessed via `ghcr.io/gubernator-io/gubernator`
- [ ] Re-enable `check-version.sh` script in github actions after new release.


