### PR TITLE
Add memberlist gossip encryption.

### DIFF
--- a/config.go
+++ b/config.go
@@ -399,6 +399,9 @@ func SetupDaemonConfig(logger *logrus.Logger, configFile io.Reader) (DaemonConfi
 	setter.SetDefault(&conf.MemberListPoolConf.MemberListAddress, os.Getenv("GUBER_MEMBERLIST_ADDRESS"), fmt.Sprintf("%s:7946", advAddr))
 	setter.SetDefault(&conf.MemberListPoolConf.KnownNodes, getEnvSlice("GUBER_MEMBERLIST_KNOWN_NODES"), []string{})
 	setter.SetDefault(&conf.MemberListPoolConf.Advertise.DataCenter, conf.DataCenter)
+	setter.SetDefault(&conf.MemberListPoolConf.EncryptionConfig.SecretKeys, getEnvSlice("GUBER_MEMBERLIST_SECRET_KEYS"), []string{})
+	setter.SetDefault(&conf.MemberListPoolConf.EncryptionConfig.GossipVerifyIncoming, getEnvBool(log, "GUBER_MEMBERLIST_GOSSIP_VERIFY_INCOMING"), true)
+	setter.SetDefault(&conf.MemberListPoolConf.EncryptionConfig.GossipVerifyOutgoing, getEnvBool(log, "GUBER_MEMBERLIST_GOSSIP_VERIFY_OUTGOING"), true)
 
 	// Kubernetes Config
 	setter.SetDefault(&conf.K8PoolConf.Namespace, os.Getenv("GUBER_K8S_NAMESPACE"), "default")

--- a/docker-compose-tls.yaml
+++ b/docker-compose-tls.yaml
@@ -9,6 +9,7 @@ services:
       - GUBER_HTTP_ADDRESS=0.0.0.0:80
       - GUBER_ADVERTISE_ADDRESS=gubernator-1:81
       - GUBER_MEMBERLIST_KNOWN_NODES=gubernator-1
+      - GUBER_MEMBERLIST_SECRET_KEYS=eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHg=
       # TLS config
       - GUBER_TLS_CA=/etc/tls/ca.pem
       - GUBER_TLS_KEY=/etc/tls/gubernator.key
@@ -29,6 +30,7 @@ services:
       - GUBER_HTTP_ADDRESS=0.0.0.0:80
       - GUBER_ADVERTISE_ADDRESS=gubernator-2:81
       - GUBER_MEMBERLIST_KNOWN_NODES=gubernator-1
+      - GUBER_MEMBERLIST_SECRET_KEYS=eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHg=
       # TLS config
       - GUBER_TLS_CA=/etc/tls/ca.pem
       - GUBER_TLS_KEY=/etc/tls/gubernator.key
@@ -49,6 +51,7 @@ services:
       - GUBER_HTTP_ADDRESS=0.0.0.0:80
       - GUBER_ADVERTISE_ADDRESS=gubernator-3:81
       - GUBER_MEMBERLIST_KNOWN_NODES=gubernator-1
+      - GUBER_MEMBERLIST_SECRET_KEYS=eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHg=
       # TLS config
       - GUBER_TLS_CA=/etc/tls/ca.pem
       - GUBER_TLS_KEY=/etc/tls/gubernator.key
@@ -70,6 +73,7 @@ services:
       - GUBER_HTTP_ADDRESS=0.0.0.0:80
       - GUBER_ADVERTISE_ADDRESS=gubernator-4:81
       - GUBER_MEMBERLIST_KNOWN_NODES=gubernator-1
+      - GUBER_MEMBERLIST_SECRET_KEYS=eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHg=
       # TLS config
       - GUBER_TLS_CA=/etc/tls/ca.pem
       - GUBER_TLS_KEY=/etc/tls/gubernator.key


### PR DESCRIPTION
This commit adds configuration fields to enable gossip encryption of memberlist. Without encryption, a malicious actor is able to add and remove members from the pool and cause general disruption to the service. Enabling encryption also acts as a pseudo-checksum and helps to ensure that no malformed UDP packets are accepted as valid messages.