### PR TITLE
fix: Bump Otel semconv version to avoid error in tracing.NewResource()

### DIFF
--- a/cmd/gubernator/main.go
+++ b/cmd/gubernator/main.go
@@ -31,7 +31,7 @@ import (
 	"github.com/mailgun/holster/v4/tracing"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"k8s.io/klog/v2"
 )
 


### PR DESCRIPTION
Hi, Currently the master branch and `ghcr.io/gubernator-io/gubernator:v2.7.1` image tag won't run with following error. 

```
INFO[0000] Gubernator dev-build (arm64/darwin)
FATA[0000] during tracing.NewResource()                  category=gubernator error="error in resource.Merge on resources index 0: conflicting Schema URL: https://opentelemetry.io/schemas/1.24.0 and https://opentelemetry.io/schemas/1.21.0"
exit status 1
```

I feel like this is similar to this commit:

https://github.com/gubernator-io/gubernator/commit/fc29185c2a58da152c85e13fcd8bb57d89f09049