### PR TITLE
Fixed possible nil err in asyncRequest

### DIFF
--- a/functional_test.go
+++ b/functional_test.go
@@ -743,11 +743,12 @@ func TestLeakyBucketGregorian(t *testing.T) {
 		},
 	}
 
-	// Truncate to the nearest minute
+	// Truncate to the nearest minute.
 	now := clock.Now()
-	now = now.Truncate(1 * time.Minute)
-	// So we don't start on the minute boundary
-	now = now.Add(time.Millisecond * 100)
+	trunc := now.Truncate(time.Hour)
+	trunc = now.Add(now.Sub(trunc))
+	clock.Advance(now.Sub(trunc))
+
 	name := t.Name()
 	key := guber.RandomString(10)
 


### PR DESCRIPTION
### Purpose
Fixes #14

### Implementation
* The `err` returned by the call to `req.Peer.GetPeerRateLimit()` shadows the local `err` which is why the `err` is nil when the max number of attempts are reached.
* Fixed flapping test `TestLeakyBucketGregorian`