### PR TITLE
Comment TraceLevelInfoFilter as it breaks OTel compatibility

### DIFF
--- a/config.go
+++ b/config.go
@@ -41,7 +41,6 @@ import (
 	"github.com/segmentio/fasthash/fnv1a"
 	"github.com/sirupsen/logrus"
 	etcd "go.etcd.io/etcd/client/v3"
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 )
 
@@ -736,20 +735,20 @@ func GetTracingLevel() tracing.Level {
 // handlers to propagate trace context.
 // However, stats handlers do not have a filter feature.
 // See: https://github.com/open-telemetry/opentelemetry-go-contrib/issues/4575
-var TraceLevelInfoFilter = otelgrpc.Filter(func(info *otelgrpc.InterceptorInfo) bool {
-	if info.UnaryServerInfo != nil {
-		if info.UnaryServerInfo.FullMethod == "/pb.gubernator.PeersV1/GetPeerRateLimits" {
-			return false
-		}
-		if info.UnaryServerInfo.FullMethod == "/pb.gubernator.V1/HealthCheck" {
-			return false
-		}
-	}
-	if info.Method == "/pb.gubernator.PeersV1/GetPeerRateLimits" {
-		return false
-	}
-	if info.Method == "/pb.gubernator.V1/HealthCheck" {
-		return false
-	}
-	return true
-})
+// var TraceLevelInfoFilter = otelgrpc.Filter(func(info *otelgrpc.InterceptorInfo) bool {
+// 	if info.UnaryServerInfo != nil {
+// 		if info.UnaryServerInfo.FullMethod == "/pb.gubernator.PeersV1/GetPeerRateLimits" {
+// 			return false
+// 		}
+// 		if info.UnaryServerInfo.FullMethod == "/pb.gubernator.V1/HealthCheck" {
+// 			return false
+// 		}
+// 	}
+// 	if info.Method == "/pb.gubernator.PeersV1/GetPeerRateLimits" {
+// 		return false
+// 	}
+// 	if info.Method == "/pb.gubernator.V1/HealthCheck" {
+// 		return false
+// 	}
+// 	return true
+// })


### PR DESCRIPTION
`TraceLevelInfoFilter` isn't used - its only use was in https://github.com/gubernator-io/gubernator/blob/e054be398e78e5daad7a3d60e9045f8991f1f8d4/daemon.go#L116 but is currently commented.

This PR unblocks consumers of gubernator who also use the latest OTel libraries (version 0.52), as the type `otelgrpc.Filter` changed in https://github.com/open-telemetry/opentelemetry-go-contrib/pull/5196 ). See change [here](https://github.com/open-telemetry/opentelemetry-go-contrib/pull/5196/files#diff-2ae5aad56db1358284b4f15a611995b358dd898126b55c3a66ce254fa58c641eR30). The code I commented is now invalid with latest versions of OTel, which prevents consumers of OTel libraries to upgrade them if they also use gubernator. Building gubernator with the latest OTel libraries fails with:

```
# github.com/gubernator-io/gubernator/v2
../../../../pkg/mod/github.com/gubernator-io/gubernator/v2@v2.7.4/config.go:739:44: cannot convert func(info *otelgrpc.InterceptorInfo) bool {…} (value of type func(info *otelgrpc.InterceptorInfo) bool) to type otelgrpc.Filter
```

Allegedly this could now be fixed with the merge of the above PR (and the code in daemon.go could be uncommented), but it requires a larger change.

I am opening this PR to unblock users of OTel and gubernator as it is the most pressing issue.

---

Commenting feels a bit weird (I did it because of the commented code in daemon.go), let me know if you want to address this differently.