### PR TITLE
Running as a non root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,6 @@ HEALTHCHECK --interval=3s --timeout=1s --start-period=2s --retries=2 CMD [ "/hea
 # Run the server
 ENTRYPOINT ["/gubernator"]
 
-EXPOSE 80
-EXPOSE 81
+EXPOSE 1050
+EXPOSE 1051
 EXPOSE 7946

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ $ docker-compose up -d
 ```
 Now you can make rate limit requests via CURL
 ```
-# Hit the HTTP API at localhost:9080 (GRPC is at 9081)
-$ curl http://localhost:9080/v1/HealthCheck
+# Hit the HTTP API at localhost:1050 (GRPC is at 1051)
+$ curl http://localhost:1050/v1/HealthCheck
 
 # Make a rate limit request
-$ curl http://localhost:9080/v1/GetRateLimits \
+$ curl http://localhost:1050/v1/GetRateLimits \
   --header 'Content-Type: application/json' \
   --data '{
     "requests": [
@@ -306,7 +306,7 @@ Example response:
       "reset_time": "1690855128786",
       "error": "",
       "metadata": {
-        "owner": "gubernator:81"
+        "owner": "gubernator:1051"
       }
     }
   ]
@@ -321,11 +321,11 @@ simplest way to try gubernator out.
 
 ##### Docker with existing etcd cluster
 ```bash
-$ docker run -p 8081:81 -p 9080:80 -e GUBER_ETCD_ENDPOINTS=etcd1:2379,etcd2:2379 \
+$ docker run -p 1051:1051 -p 1050:1050 -e GUBER_ETCD_ENDPOINTS=etcd1:2379,etcd2:2379 \
    ghcr.io/gubernator-io/gubernator:latest
 
-# Hit the HTTP API at localhost:9080
-$ curl http://localhost:9080/v1/HealthCheck
+# Hit the HTTP API at localhost:1050
+$ curl http://localhost:1050/v1/HealthCheck
 ```
 
 ##### Kubernetes
@@ -352,8 +352,8 @@ self signed certs by running `docker-compose-tls.yaml`
 # Run docker compose
 $ docker-compose -f docker-compose-tls.yaml up -d
 
-# Hit the HTTP API at localhost:9080 (GRPC is at 9081)
-$ curl --cacert certs/ca.cert --cert certs/gubernator.pem --key certs/gubernator.key  https://localhost:9080/v1/HealthCheck
+# Hit the HTTP API at localhost:1050 (GRPC is at 1051)
+$ curl --cacert certs/ca.cert --cert certs/gubernator.pem --key certs/gubernator.key  https://localhost:1050/v1/HealthCheck
 ```
 
 ### Configuration

--- a/cmd/gubernator/main_test.go
+++ b/cmd/gubernator/main_test.go
@@ -15,10 +15,11 @@ import (
 	"testing"
 	"time"
 
-	cli "github.com/gubernator-io/gubernator/v2/cmd/gubernator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/proxy"
+
+	cli "github.com/gubernator-io/gubernator/v2/cmd/gubernator"
 )
 
 var cliRunning = flag.Bool("test_cli_running", false, "True if running as a child process; used by TestCLI")
@@ -45,8 +46,8 @@ func TestCLI(t *testing.T) {
 		{
 			name: "Should start with no config provided",
 			env: []string{
-				"GUBER_GRPC_ADDRESS=localhost:8080",
-				"GUBER_HTTP_ADDRESS=localhost:8081",
+				"GUBER_GRPC_ADDRESS=localhost:1050",
+				"GUBER_HTTP_ADDRESS=localhost:1051",
 			},
 			args:     []string{},
 			contains: "HTTP Gateway Listening on",
@@ -73,7 +74,7 @@ func TestCLI(t *testing.T) {
 				close(waitCh)
 			}()
 
-			err := waitForConnect(ctx, "localhost:8080", nil)
+			err := waitForConnect(ctx, "localhost:1050", nil)
 			assert.NoError(t, err)
 			time.Sleep(time.Second * 1)
 

--- a/cmd/healthcheck/main.go
+++ b/cmd/healthcheck/main.go
@@ -29,7 +29,7 @@ import (
 func main() {
 	url := os.Getenv("GUBER_HTTP_ADDRESS")
 	if url == "" {
-		url = "localhost:80"
+		url = "localhost:1050"
 	}
 	resp, err := http.DefaultClient.Get(fmt.Sprintf("http://%s/v1/HealthCheck", url))
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -310,9 +310,9 @@ func SetupDaemonConfig(logger *logrus.Logger, configFile io.Reader) (DaemonConfi
 
 	// Main config
 	setter.SetDefault(&conf.GRPCListenAddress, os.Getenv("GUBER_GRPC_ADDRESS"),
-		fmt.Sprintf("%s:81", LocalHost()))
+		fmt.Sprintf("%s:1051", LocalHost()))
 	setter.SetDefault(&conf.HTTPListenAddress, os.Getenv("GUBER_HTTP_ADDRESS"),
-		fmt.Sprintf("%s:80", LocalHost()))
+		fmt.Sprintf("%s:1050", LocalHost()))
 	setter.SetDefault(&conf.InstanceID, GetInstanceID())
 	setter.SetDefault(&conf.HTTPStatusListenAddress, os.Getenv("GUBER_STATUS_HTTP_ADDRESS"), "")
 	setter.SetDefault(&conf.GRPCMaxConnectionAgeSeconds, getEnvInteger(log, "GUBER_GRPC_MAX_CONN_AGE_SEC"), 0)

--- a/config_test.go
+++ b/config_test.go
@@ -21,13 +21,14 @@ GUBER_GRPC_ADDRESS=10.10.10.10:9000`
 	require.NotEmpty(t, daemonConfig.InstanceID)
 }
 
-func TestDefaultGrpcAddress(t *testing.T) {
+func TestDefaultListenAddress(t *testing.T) {
 	os.Clearenv()
 	s := `
 # a comment`
 	daemonConfig, err := SetupDaemonConfig(logrus.StandardLogger(), strings.NewReader(s))
 	require.NoError(t, err)
-	require.Equal(t, fmt.Sprintf("%s:81", LocalHost()), daemonConfig.GRPCListenAddress)
+	require.Equal(t, fmt.Sprintf("%s:1051", LocalHost()), daemonConfig.GRPCListenAddress)
+	require.Equal(t, fmt.Sprintf("%s:1050", LocalHost()), daemonConfig.HTTPListenAddress)
 	require.NotEmpty(t, daemonConfig.InstanceID)
 }
 

--- a/contrib/aws-ecs-service-discovery-deployment/ecs_gubernator.tf
+++ b/contrib/aws-ecs-service-discovery-deployment/ecs_gubernator.tf
@@ -35,8 +35,8 @@ module "gubernator_service" {
           initProcessEnabled = true
         },
         portMappings = [
-          { containerPort = 80 },
-          { containerPort = 81 },
+          { containerPort = 1050 },
+          { containerPort = 1051 },
         ],
         logConfiguration = {
           logDriver = "awslogs",

--- a/contrib/aws-ecs-service-discovery-deployment/main.tf
+++ b/contrib/aws-ecs-service-discovery-deployment/main.tf
@@ -3,8 +3,8 @@ locals {
   gubernator_service_discovery = "app"
   gubernator_service_host      = "${local.gubernator_service_discovery}.${local.service_namespace}"
   gubernator_env_vars = {
-    GUBER_GRPC_ADDRESS        = "0.0.0.0:81"
-    GUBER_HTTP_ADDRESS        = "0.0.0.0:80"
+    GUBER_GRPC_ADDRESS        = "0.0.0.0:1051"
+    GUBER_HTTP_ADDRESS        = "0.0.0.0:1050"
     GUBER_PEER_DISCOVERY_TYPE = "dns"
     GUBER_DNS_FQDN            = local.gubernator_service_host
     GUBER_DEBUG               = var.gubernator_debug_mode ? "true" : "false"

--- a/contrib/charts/gubernator/templates/_helpers.tpl
+++ b/contrib/charts/gubernator/templates/_helpers.tpl
@@ -67,7 +67,7 @@ GRPC Port
 {{- if .Values.gubernator.server.grpc.port }}
 {{- .Values.gubernator.server.grpc.port}}
 {{- else }}
-{{- print "81" }}
+{{- print "1051" }}
 {{- end }}
 {{- end }}
 
@@ -78,7 +78,7 @@ HTTP Port
 {{- if .Values.gubernator.server.http.port }}
 {{- .Values.gubernator.server.http.port}}
 {{- else }}
-{{- print "80" }}
+{{- print "1050" }}
 {{- end }}
 {{- end }}
 

--- a/contrib/charts/gubernator/values.yaml
+++ b/contrib/charts/gubernator/values.yaml
@@ -31,9 +31,9 @@ gubernator:
 
   server:
     http:
-      port: "80"
+      port: "1050"
     grpc:
-      port: "81"
+      port: "1051"
       # Defines the max age of a client connection
       # default is infinity
       # maxConnAgeSeconds: 30

--- a/contrib/k8s-deployment.yaml
+++ b/contrib/k8s-deployment.yaml
@@ -15,6 +15,12 @@ spec:
         app: gubernator
     spec:
       serviceAccountName: gubernator
+      # If using the default ports 80 and 81, you need to grant permissions to avoid bind permission denied
+      # securityContext:
+      #   runAsNonRoot: true
+      #   sysctls:
+      #     - name: net.ipv4.ip_unprivileged_port_start
+      #       value: "80"
       containers:
         - image: ghcr.io/gubernator-io/gubernator:latest
           imagePullPolicy: IfNotPresent

--- a/contrib/k8s-deployment.yaml
+++ b/contrib/k8s-deployment.yaml
@@ -15,21 +15,14 @@ spec:
         app: gubernator
     spec:
       serviceAccountName: gubernator
-      # If using the default ports 80 and 81 and containerd runtime, you need to grant permissions to avoid bind
-      # permission denied
-      # securityContext:
-      #   runAsNonRoot: true
-      #   sysctls:
-      #     - name: net.ipv4.ip_unprivileged_port_start
-      #       value: "80"
       containers:
         - image: ghcr.io/gubernator-io/gubernator:latest
           imagePullPolicy: IfNotPresent
           ports:
             - name: grpc-port
-              containerPort: 81
+              containerPort: 1051
             - name: http-port
-              containerPort: 80
+              containerPort: 1050
           name: gubernator
           env:
           - name: GUBER_K8S_NAMESPACE
@@ -43,16 +36,16 @@ spec:
           # Must set the GRPC and HTTP addresses, as gubernator
           # defaults to listening on localhost only
           - name: GUBER_GRPC_ADDRESS
-            value: 0.0.0.0:81
+            value: 0.0.0.0:1051
           - name: GUBER_HTTP_ADDRESS
-            value: 0.0.0.0:80
+            value: 0.0.0.0:1050
           # Use the k8s API for peer discovery
           - name: GUBER_PEER_DISCOVERY_TYPE
             value: "k8s"
           # This should match the port number GRPC is listening on
           # as defined by `containerPort`
           - name: GUBER_K8S_POD_PORT
-            value: "81"
+            value: "1051"
           # The selector used when listing endpoints. This selector
           # should only select gubernator peers.
           - name: GUBER_K8S_ENDPOINTS_SELECTOR
@@ -81,13 +74,13 @@ spec:
   clusterIP: None
   #ports:
   #- name: grpc-port
-  #targetPort: 81
+  #targetPort: 1051
   #protocol: TCP
-  #port: 81
+  #port: 1051
   #- name: http-port
-  #targetPort: 80
+  #targetPort: 1050
   #protocol: TCP
-  #port: 80
+  #port: 1050
   selector:
     app: gubernator
 ---

--- a/contrib/k8s-deployment.yaml
+++ b/contrib/k8s-deployment.yaml
@@ -15,7 +15,8 @@ spec:
         app: gubernator
     spec:
       serviceAccountName: gubernator
-      # If using the default ports 80 and 81, you need to grant permissions to avoid bind permission denied
+      # If using the default ports 80 and 81 and containerd runtime, you need to grant permissions to avoid bind
+      # permission denied
       # securityContext:
       #   runAsNonRoot: true
       #   sysctls:

--- a/dns.go
+++ b/dns.go
@@ -157,10 +157,10 @@ func peer(ip string, self string, ipv6 bool) PeerInfo {
 	if ipv6 {
 		ip = "[" + ip + "]"
 	}
-	grpc := ip + ":81"
+	grpc := ip + ":1051"
 	return PeerInfo{
 		DataCenter:  "",
-		HTTPAddress: ip + ":80",
+		HTTPAddress: ip + ":1050",
 		GRPCAddress: grpc,
 		IsOwner:     grpc == self,
 	}

--- a/docker-compose-tls.yaml
+++ b/docker-compose-tls.yaml
@@ -5,9 +5,9 @@ services:
     entrypoint: "/gubernator"
     environment:
       # Basic member-list config
-      - GUBER_GRPC_ADDRESS=0.0.0.0:81
-      - GUBER_HTTP_ADDRESS=0.0.0.0:80
-      - GUBER_ADVERTISE_ADDRESS=gubernator-1:81
+      - GUBER_GRPC_ADDRESS=0.0.0.0:1051
+      - GUBER_HTTP_ADDRESS=0.0.0.0:1050
+      - GUBER_ADVERTISE_ADDRESS=gubernator-1:1051
       - GUBER_MEMBERLIST_KNOWN_NODES=gubernator-1
       - GUBER_MEMBERLIST_SECRET_KEYS=eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHg=
       # TLS config
@@ -16,8 +16,8 @@ services:
       - GUBER_TLS_CERT=/etc/tls/gubernator.pem
       - GUBER_TLS_CLIENT_AUTH=require-and-verify
     ports:
-      - "9081:81"
-      - "9080:80"
+      - "1051:1051"
+      - "1050:1050"
     volumes:
       - ${PWD}/contrib/certs:/etc/tls
 
@@ -26,9 +26,9 @@ services:
     entrypoint: "/gubernator"
     environment:
       # Basic member-list config
-      - GUBER_GRPC_ADDRESS=0.0.0.0:81
-      - GUBER_HTTP_ADDRESS=0.0.0.0:80
-      - GUBER_ADVERTISE_ADDRESS=gubernator-2:81
+      - GUBER_GRPC_ADDRESS=0.0.0.0:1051
+      - GUBER_HTTP_ADDRESS=0.0.0.0:1050
+      - GUBER_ADVERTISE_ADDRESS=gubernator-2:1051
       - GUBER_MEMBERLIST_KNOWN_NODES=gubernator-1
       - GUBER_MEMBERLIST_SECRET_KEYS=eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHg=
       # TLS config
@@ -37,8 +37,8 @@ services:
       - GUBER_TLS_CERT=/etc/tls/gubernator.pem
       - GUBER_TLS_CLIENT_AUTH=require-and-verify
     ports:
-      - "9181:81"
-      - "9180:80"
+      - "1151:1051"
+      - "1150:1050"
     volumes:
       - ${PWD}/contrib/certs:/etc/tls
 
@@ -47,9 +47,9 @@ services:
     entrypoint: "/gubernator"
     environment:
       # Basic member-list config
-      - GUBER_GRPC_ADDRESS=0.0.0.0:81
-      - GUBER_HTTP_ADDRESS=0.0.0.0:80
-      - GUBER_ADVERTISE_ADDRESS=gubernator-3:81
+      - GUBER_GRPC_ADDRESS=0.0.0.0:1051
+      - GUBER_HTTP_ADDRESS=0.0.0.0:1050
+      - GUBER_ADVERTISE_ADDRESS=gubernator-3:1051
       - GUBER_MEMBERLIST_KNOWN_NODES=gubernator-1
       - GUBER_MEMBERLIST_SECRET_KEYS=eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHg=
       # TLS config
@@ -58,8 +58,8 @@ services:
       - GUBER_TLS_CERT=/etc/tls/gubernator.pem
       - GUBER_TLS_CLIENT_AUTH=require-and-verify
     ports:
-      - "9281:81"
-      - "9280:80"
+      - "1251:1051"
+      - "1250:1050"
     volumes:
       - ${PWD}/contrib/certs:/etc/tls
 
@@ -69,9 +69,9 @@ services:
     environment:
       # Basic member-list config
       - GUBER_DEBUG=true
-      - GUBER_GRPC_ADDRESS=0.0.0.0:81
-      - GUBER_HTTP_ADDRESS=0.0.0.0:80
-      - GUBER_ADVERTISE_ADDRESS=gubernator-4:81
+      - GUBER_GRPC_ADDRESS=0.0.0.0:1051
+      - GUBER_HTTP_ADDRESS=0.0.0.0:1050
+      - GUBER_ADVERTISE_ADDRESS=gubernator-4:1051
       - GUBER_MEMBERLIST_KNOWN_NODES=gubernator-1
       - GUBER_MEMBERLIST_SECRET_KEYS=eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHg=
       # TLS config
@@ -80,7 +80,7 @@ services:
       - GUBER_TLS_CERT=/etc/tls/gubernator.pem
       - GUBER_TLS_CLIENT_AUTH=require-and-verify
     ports:
-      - "9381:81"
-      - "9380:80"
+      - "1351:1051"
+      - "1350:1050"
     volumes:
       - ${PWD}/contrib/certs:/etc/tls

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,51 +5,51 @@ services:
     entrypoint: "/gubernator"
     environment:
       # The address GRPC requests will listen on
-      - GUBER_GRPC_ADDRESS=0.0.0.0:81
+      - GUBER_GRPC_ADDRESS=0.0.0.0:1051
       # The address HTTP requests will listen on
-      - GUBER_HTTP_ADDRESS=0.0.0.0:80
+      - GUBER_HTTP_ADDRESS=0.0.0.0:1050
       # The address that is advertised to other peers
-      - GUBER_ADVERTISE_ADDRESS=gubernator-1:81
+      - GUBER_ADVERTISE_ADDRESS=gubernator-1:1051
       # A comma separated list of known gubernator nodes
       - GUBER_MEMBERLIST_KNOWN_NODES=gubernator-1
       #- GUBER_DATA_CENTER=us-east-1
     ports:
-      - "9081:81"
-      - "9080:80"
+      - "1051:1051"
+      - "1050:1050"
 
   gubernator-2:
     image: ghcr.io/gubernator-io/gubernator:latest
     entrypoint: "/gubernator"
     environment:
       # The address GRPC requests will listen on
-      - GUBER_GRPC_ADDRESS=0.0.0.0:81
+      - GUBER_GRPC_ADDRESS=0.0.0.0:1051
       # The address HTTP requests will listen on
-      - GUBER_HTTP_ADDRESS=0.0.0.0:80
+      - GUBER_HTTP_ADDRESS=0.0.0.0:1050
       # The address that is advertised to other peers
-      - GUBER_ADVERTISE_ADDRESS=gubernator-2:81
+      - GUBER_ADVERTISE_ADDRESS=gubernator-2:1051
       # A comma separated list of known gubernator nodes
       - GUBER_MEMBERLIST_KNOWN_NODES=gubernator-1
       #- GUBER_DATA_CENTER=us-east-1
     ports:
-      - "9181:81"
-      - "9180:80"
+      - "1151:1051"
+      - "1150:1050"
 
   gubernator-3:
     image: ghcr.io/gubernator-io/gubernator:latest
     entrypoint: "/gubernator"
     environment:
       # The address GRPC requests will listen on
-      - GUBER_GRPC_ADDRESS=0.0.0.0:81
+      - GUBER_GRPC_ADDRESS=0.0.0.0:1051
       # The address HTTP requests will listen on
-      - GUBER_HTTP_ADDRESS=0.0.0.0:80
+      - GUBER_HTTP_ADDRESS=0.0.0.0:1050
       # The address that is advertised to other peers
-      - GUBER_ADVERTISE_ADDRESS=gubernator-3:81
+      - GUBER_ADVERTISE_ADDRESS=gubernator-3:1051
       # A comma separated list of known gubernator nodes
       - GUBER_MEMBERLIST_KNOWN_NODES=gubernator-1
       #- GUBER_DATA_CENTER=us-west-2
     ports:
-      - "9281:81"
-      - "9280:80"
+      - "1251:1051"
+      - "1250:1050"
 
   gubernator-4:
     image: ghcr.io/gubernator-io/gubernator:latest
@@ -57,15 +57,15 @@ services:
     environment:
       - GUBER_DEBUG=true
       # The address GRPC requests will listen on
-      - GUBER_GRPC_ADDRESS=0.0.0.0:81
+      - GUBER_GRPC_ADDRESS=0.0.0.0:1051
       # The address HTTP requests will listen on
-      - GUBER_HTTP_ADDRESS=0.0.0.0:80
+      - GUBER_HTTP_ADDRESS=0.0.0.0:1050
       # The address that is advertised to other peers
-      - GUBER_ADVERTISE_ADDRESS=gubernator-4:81
+      - GUBER_ADVERTISE_ADDRESS=gubernator-4:1051
       # A Comma separated list of known gubernator nodes
       - GUBER_MEMBERLIST_KNOWN_NODES=gubernator-1,gubernator-2
       #- GUBER_DATA_CENTER=us-west-2
       #- GUBER_METRIC_FLAGS=golang,os
     ports:
-      - "9381:81"
-      - "9380:80"
+      - "1351:1051"
+      - "1350:1050"

--- a/example.conf
+++ b/example.conf
@@ -3,10 +3,10 @@
 ############################
 
 # The address GRPC requests will listen on
-GUBER_GRPC_ADDRESS=0.0.0.0:9990
+GUBER_GRPC_ADDRESS=0.0.0.0:1051
 
 # The address HTTP requests will listen on
-GUBER_HTTP_ADDRESS=0.0.0.0:9980
+GUBER_HTTP_ADDRESS=0.0.0.0:1050
 
 # The address gubernator peers will connect to. Ignored if using k8s peer
 # discovery method.
@@ -16,7 +16,7 @@ GUBER_HTTP_ADDRESS=0.0.0.0:9980
 #
 # If unset, will default to the hostname or if that fails will attempt
 # to guess at a non loopback interface
-GUBER_ADVERTISE_ADDRESS=localhost:9990
+GUBER_ADVERTISE_ADDRESS=localhost:1051
 
 # A unique id which identifies this instance of gubernator. This
 # id is used in tracing and logging to identify this instance.
@@ -139,15 +139,15 @@ GUBER_INSTANCE_ID=<unique-id>
 ############################
 
 # The address peers will connect too. Defaults to GUBER_ADVERTISE_ADDRESS
-# GUBER_MEMBERLIST_ADVERTISE_ADDRESS=localhost:81
+# GUBER_MEMBERLIST_ADVERTISE_ADDRESS=localhost:1051
 
 # The address the member list will listen to in order to discover other list members.
 # This should be a different port than GUBER_ADVERTISE_ADDRESS
-# GUBER_MEMBERLIST_ADDRESS=localhost:7946
+# GUBER_MEMBERLIST_ADDRESS=localhost:1051
 
 # This is an initial list or a single domain name that 'member-list' will connect to in order to
 # begin discovering other peers.
-# GUBER_MEMBERLIST_KNOWN_NODES=peer1:7946,peer2:7946,peer3:7946
+# GUBER_MEMBERLIST_KNOWN_NODES=peer1:1051,peer2:1051,peer3:1051
 # GUBER_MEMBERLIST_KNOWN_NODES=memberlist.example.com
 
 
@@ -181,7 +181,7 @@ GUBER_INSTANCE_ID=<unique-id>
 # GUBER_ETCD_ENDPOINTS=localhost:2379
 
 # The address peers will connect too. Defaults to GUBER_ADVERTISE_ADDRESS
-# GUBER_ETCD_ADVERTISE_ADDRESS=localhost:81
+# GUBER_ETCD_ADVERTISE_ADDRESS=localhost:1051
 
 # The prefix gubernator will use to register peers under in etcd
 #GUBER_ETCD_KEY_PREFIX=/gubernator-peers


### PR DESCRIPTION
Issue: https://github.com/gubernator-io/gubernator/issues/27

This adds a non root user to the Dockerfile that by default assumes the root user.

You can test it works locally like this:

<details>
<summary>Use this K8s manifest.</summary>

```yaml
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: gubernator
---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: get-endpoints
rules:
  - apiGroups:
      - ""
    resources:
      - endpoints
    verbs:
      - list
      - watch
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: get-endpoints
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: get-endpoints
subjects:
  - kind: ServiceAccount
    name: gubernator
---
apiVersion: v1
kind: Pod
metadata:
  name: gubernator
  labels:
    app: gubernator
spec:
  securityContext:
    runAsNonRoot: true
  serviceAccountName: gubernator
  containers:
    - image: custom-image:latest
      imagePullPolicy: IfNotPresent
      ports:
        - name: grpc-port
          containerPort: 1081
        - name: http-port
          containerPort: 1080
      name: gubernator
      env:
      - name: GUBER_K8S_NAMESPACE
        valueFrom:
          fieldRef:
            fieldPath: metadata.namespace
      - name: GUBER_K8S_POD_IP
        valueFrom:
          fieldRef:
            fieldPath: status.podIP
      # Must set the GRPC and HTTP addresses, as gubernator
      # defaults to listening on localhost only
      - name: GUBER_GRPC_ADDRESS
        value: 0.0.0.0:1081
      - name: GUBER_HTTP_ADDRESS
        value: 0.0.0.0:1080
      # Use the k8s API for peer discovery
      - name: GUBER_PEER_DISCOVERY_TYPE
        value: "k8s"
      # This should match the port number GRPC is listening on
      # as defined by `containerPort`
      - name: GUBER_K8S_POD_PORT
        value: "1081"
      # The selector used when listing endpoints. This selector
      # should only select gubernator peers.
      - name: GUBER_K8S_ENDPOINTS_SELECTOR
        value: "app=gubernator"
      # Gubernator can watch 'endpoints' for changes to the peers
      # or it can watch 'pods' (Defaults to 'endpoints')
      # - name: GUBER_K8S_WATCH_MECHANISM
      #  value: "endpoints"
      # Enable debug for diagnosing issues
      - name: GUBER_DEBUG
        value: "true"
      # Defines the max age of a client connection
      # Default is infinity
      # - name: GUBER_GRPC_MAX_CONN_AGE_SEC
      #  value: "30"

  restartPolicy: Always
---
apiVersion: v1
kind: Service
metadata:
  name: gubernator
  labels:
    app: gubernator
spec:
  type: LoadBalancer
  ports:
  - targetPort: 1080
    port: 1080
  selector:
    app: gubernator

```
</details>


<details>
<summary>Use this script.</summary>

```sh

# delete local cluster if exists
kind delete cluster

# expose load balancer
cloud-provider-kind > cloud-provider-kind.log 2>&1 &
kind create cluster

docker build -t custom-image .
kind load docker-image custom-image:latest
# ensure gubernator pod is using image: custom-image:latest
kubectl apply -f k8s-deployment.yaml

# wait until gubernator is ready
kubectl wait --for=jsonpath='{.status.loadBalancer.ingress}' service/gubernator
kubectl wait --for=condition=Ready pod/gubernator --timeout=5m

# check the pod and service
kubectl get all

# make a request
IP=$(kubectl get service/gubernator -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')
ENDPOINT="http://$IP:1080/v1/GetRateLimits"
echo "ENDPOINT IS $ENDPOINT"
curl $ENDPOINT \
  --header 'Content-Type: application/json' \
  --data '{
    "requests": [
        {
            "name": "requests_per_sec",
            "uniqueKey": "account:12345",
            "hits": "1",
            "limit": "10",
            "duration": "1000"
        }
    ]
}'
```
</details>

The curl should work and output:

```
{"responses":[{"status":"UNDER_LIMIT","limit":"10","remaining":"9","reset_time":"1727876656143","error":"","metadata":{}}]}
```