### PR TITLE
Add hook to `GetRateLimit`

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: ./go.mod
           cache: true # caching and restoring go modules and build outputs
@@ -29,7 +29,7 @@ jobs:
         run: go mod tidy && git diff --exit-code
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           skip-cache: true # cache/restore is done by actions/setup-go@v3 step

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  GOLANGCI_LINT_VERSION: v1.56.2
+  GOLANGCI_LINT_VERSION: v1.61.0
 
 jobs:
   lint:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches: [ master ]
 
-env:
-  GOLANGCI_LINT_VERSION: v1.56.2
-
 jobs:
   test:
     name: test
@@ -40,14 +37,9 @@ jobs:
       - name: Install deps
         run: go mod download
 
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
-        with:
-          version: ${{ env.GOLANGCI_LINT_VERSION }}
-          skip-cache: true
-
       - name: Test
         run: go test -v -race -p=1 -count=1 -tags holster_test_mode
+
   go-bench:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 VERSION=$(shell cat version)
 LDFLAGS="-X main.Version=$(VERSION)"
 GOLANGCI_LINT = $(GOPATH)/bin/golangci-lint
-GOLANGCI_LINT_VERSION = 1.56.2
+GOLANGCI_LINT_VERSION = v1.56.2
 
 .PHONY: help
 help:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 VERSION=$(shell cat version)
 LDFLAGS="-X main.Version=$(VERSION)"
 GOLANGCI_LINT = $(GOPATH)/bin/golangci-lint
-GOLANGCI_LINT_VERSION = v1.56.2
+GOLANGCI_LINT_VERSION = v1.61.0
 
 .PHONY: help
 help:

--- a/cmd/gubernator-cli/main.go
+++ b/cmd/gubernator-cli/main.go
@@ -170,7 +170,7 @@ func min(a, b int) int {
 
 func checkErr(err error) {
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatal(err.Error())
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -256,6 +256,9 @@ type DaemonConfig struct {
 	// (Optional) TraceLevel sets the tracing level, this controls the number of spans included in a single trace.
 	//  Valid options are (tracing.InfoLevel, tracing.DebugLevel) Defaults to tracing.InfoLevel
 	TraceLevel tracing.Level
+
+	// (Optional) EventChannel receives hit events
+	EventChannel chan<- HitEvent
 }
 
 func (d *DaemonConfig) ClientTLS() *tls.Config {

--- a/config.go
+++ b/config.go
@@ -119,6 +119,14 @@ type Config struct {
 
 	// (Optional) The total size of the cache used to store rate limits. Defaults to 50,000
 	CacheSize int
+
+	// (Optional) EventChannel receives hit events
+	EventChannel chan HitEvent
+}
+
+type HitEvent struct {
+	Request  *RateLimitReq
+	Response *RateLimitResp
 }
 
 func (c *Config) SetDefaults() error {

--- a/config.go
+++ b/config.go
@@ -121,7 +121,7 @@ type Config struct {
 	CacheSize int
 
 	// (Optional) EventChannel receives hit events
-	EventChannel chan HitEvent
+	EventChannel chan<- HitEvent
 }
 
 type HitEvent struct {

--- a/daemon.go
+++ b/daemon.go
@@ -156,6 +156,7 @@ func (s *Daemon) Start(ctx context.Context) error {
 		CacheSize:     s.conf.CacheSize,
 		Workers:       s.conf.Workers,
 		InstanceID:    s.conf.InstanceID,
+		EventChannel:  s.conf.EventChannel,
 	}
 
 	s.V1Server, err = NewV1Instance(s.instanceConf)

--- a/functional_test.go
+++ b/functional_test.go
@@ -2113,6 +2113,11 @@ func TestEventChannel(t *testing.T) {
 	}()
 
 	// Spawn specialized Gubernator cluster with EventChannel enabled.
+	cluster.Stop()
+	defer func() {
+		err := startGubernator()
+		require.NoError(t, err)
+	}()
 	peers := []guber.PeerInfo{
 		{GRPCAddress: "127.0.0.1:10000", HTTPAddress: "127.0.0.1:10001", DataCenter: cluster.DataCenterNone},
 		{GRPCAddress: "127.0.0.1:10002", HTTPAddress: "127.0.0.1:10003", DataCenter: cluster.DataCenterNone},

--- a/gubernator.go
+++ b/gubernator.go
@@ -608,6 +608,18 @@ func (s *V1Instance) getLocalRateLimit(ctx context.Context, r *RateLimitReq, req
 
 	if reqState.IsOwner {
 		metricGetRateLimitCounter.WithLabelValues("local").Inc()
+
+		// Send to event channel, if set.
+		if s.conf.EventChannel != nil {
+			e := HitEvent{
+				Request:  r,
+				Response: resp,
+			}
+			select {
+			case s.conf.EventChannel <- e:
+			case <-ctx.Done():
+			}
+		}
 	}
 	return resp, nil
 }


### PR DESCRIPTION
This PR implements a generalized hook into rate limit hits by providing a unidirectional channel to receive request/response data.  The initial use case is to implement Prometheus metrics to monitor status of high value rate limit name/key pairs.

The user will populate `Config.EventChannel` with a channel and implement goroutine(s) to read from the channel.  An event is triggered when a rate limit hit is applied at its owner peer and request/response structures are sent to the channel.

This is intended to work for all peering behaviors: batching, non-batching, and global.

Other auxiliary changes:
- Upgrade `golangci-lint` to latest.
- Update GitHub Actions in workflows.
- Remove redundant call to `golangci-lint` in `on-pull-request` workflow.
- `cluster.StartWith()` extended with options arguments to add support for `EventChannel`.