### PR TITLE
Attempt to switch logging to Go standard slog SDK logging

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -19,12 +19,13 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"math/rand"
 
-	"github.com/gubernator-io/gubernator/v3"
 	"github.com/mailgun/holster/v4/clock"
 	"github.com/mailgun/holster/v4/errors"
-	"github.com/sirupsen/logrus"
+
+	"github.com/gubernator-io/gubernator/v3"
 )
 
 const (
@@ -176,7 +177,7 @@ func StartWith(localPeers []gubernator.PeerInfo, opts ...Option) error {
 	for _, peer := range localPeers {
 		ctx, cancel := context.WithTimeout(context.Background(), clock.Second*10)
 		cfg := gubernator.DaemonConfig{
-			Logger:            logrus.WithField("instance", peer.HTTPAddress),
+			Logger:            slog.Default().With("instance", peer.HTTPAddress),
 			InstanceID:        peer.HTTPAddress,
 			HTTPListenAddress: peer.HTTPAddress,
 			AdvertiseAddress:  peer.HTTPAddress,

--- a/cmd/gubernator-cluster/main.go
+++ b/cmd/gubernator-cluster/main.go
@@ -24,12 +24,10 @@ import (
 
 	"github.com/gubernator-io/gubernator/v3"
 	"github.com/gubernator-io/gubernator/v3/cluster"
-	"github.com/sirupsen/logrus"
 )
 
 // Start a cluster of gubernator instances for use in testing clients
 func main() {
-	logrus.SetLevel(logrus.InfoLevel)
 	// Start a local cluster
 	err := cluster.StartWith([]gubernator.PeerInfo{
 		{HTTPAddress: "127.0.0.1:9980"},

--- a/cmd/gubernator/main_test.go
+++ b/cmd/gubernator/main_test.go
@@ -15,12 +15,11 @@ import (
 	"testing"
 	"time"
 
-	cli "github.com/gubernator-io/gubernator/v3/cmd/gubernator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/proxy"
 
-	cli "github.com/gubernator-io/gubernator/v2/cmd/gubernator"
+	cli "github.com/gubernator-io/gubernator/v3/cmd/gubernator"
 )
 
 var cliRunning = flag.Bool("test_cli_running", false, "True if running as a child process; used by TestCLI")
@@ -50,7 +49,7 @@ func TestCLI(t *testing.T) {
 				"GUBER_HTTP_ADDRESS=localhost:8080",
 			},
 			args:     []string{},
-			contains: "HTTP Listening on",
+			contains: "HTTP Listening",
 		},
 	}
 	for _, tt := range tests {

--- a/config_test.go
+++ b/config_test.go
@@ -2,11 +2,11 @@ package gubernator
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,7 +15,7 @@ func TestParsesAddress(t *testing.T) {
 	s := `
 # a comment
 GUBER_HTTP_ADDRESS=10.10.10.10:9000`
-	daemonConfig, err := SetupDaemonConfig(logrus.StandardLogger(), strings.NewReader(s))
+	daemonConfig, err := SetupDaemonConfig(slog.New(slog.NewTextHandler(os.Stderr, nil)), strings.NewReader(s))
 	require.NoError(t, err)
 	require.Equal(t, "10.10.10.10:9000", daemonConfig.HTTPListenAddress)
 	require.NotEmpty(t, daemonConfig.InstanceID)
@@ -25,7 +25,7 @@ func TestDefaultListenAddress(t *testing.T) {
 	os.Clearenv()
 	s := `
 # a comment`
-	daemonConfig, err := SetupDaemonConfig(logrus.StandardLogger(), strings.NewReader(s))
+	daemonConfig, err := SetupDaemonConfig(slog.New(slog.NewTextHandler(os.Stderr, nil)), strings.NewReader(s))
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("%s:1050", LocalHost()), daemonConfig.HTTPListenAddress)
 	require.NotEmpty(t, daemonConfig.InstanceID)
@@ -34,7 +34,7 @@ func TestDefaultListenAddress(t *testing.T) {
 func TestDefaultInstanceId(t *testing.T) {
 	os.Clearenv()
 	s := ``
-	daemonConfig, err := SetupDaemonConfig(logrus.StandardLogger(), strings.NewReader(s))
+	daemonConfig, err := SetupDaemonConfig(slog.New(slog.NewTextHandler(os.Stderr, nil)), strings.NewReader(s))
 	require.NoError(t, err)
 	require.NotEmpty(t, daemonConfig.InstanceID)
 }

--- a/dns.go
+++ b/dns.go
@@ -18,6 +18,7 @@ package gubernator
 
 import (
 	"context"
+	"log/slog"
 	"math/rand"
 	"net"
 	"os"
@@ -26,7 +27,6 @@ import (
 	"github.com/mailgun/holster/v4/setter"
 	"github.com/miekg/dns"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 // DNSResolver represents a dns resolver
@@ -135,7 +135,7 @@ type DNSPool struct {
 }
 
 func NewDNSPool(conf DNSPoolConfig) (*DNSPool, error) {
-	setter.SetDefault(&conf.Logger, logrus.WithField("category", "gubernator"))
+	setter.SetDefault(&conf.Logger, slog.New(slog.NewTextHandler(os.Stderr, nil)).With("category", "gubernator"))
 
 	if conf.OwnAddress == "" {
 		return nil, errors.New("AdvertiseAddress is required")

--- a/etcd.go
+++ b/etcd.go
@@ -19,12 +19,12 @@ package gubernator
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 
 	"github.com/mailgun/holster/v4/clock"
 	"github.com/mailgun/holster/v4/errors"
 	"github.com/mailgun/holster/v4/setter"
 	"github.com/mailgun/holster/v4/syncutil"
-	"github.com/sirupsen/logrus"
 	etcd "go.etcd.io/etcd/client/v3"
 )
 
@@ -72,7 +72,7 @@ type EtcdPoolConfig struct {
 
 func NewEtcdPool(conf EtcdPoolConfig) (*EtcdPool, error) {
 	setter.SetDefault(&conf.KeyPrefix, defaultBaseKey)
-	setter.SetDefault(&conf.Logger, logrus.WithField("category", "gubernator"))
+	setter.SetDefault(&conf.Logger, slog.Default().With("category", "gubernator"))
 
 	if conf.Advertise.HTTPAddress == "" {
 		return nil, errors.New("Advertise.HTTPAddress is required")
@@ -130,7 +130,10 @@ func (e *EtcdPool) watchPeers() error {
 
 	select {
 	case <-ready:
-		e.log.Infof("watching for peer changes '%s' at revision %d", e.conf.KeyPrefix, revision)
+		e.log.LogAttrs(context.TODO(), slog.LevelInfo, "watching for peer changes",
+			slog.String("key_prefix", e.conf.KeyPrefix),
+			slog.Int64("revision", revision),
+		)
 	case <-clock.After(etcdTimeout):
 		return errors.New("timed out while waiting for watcher.Watch() to start")
 	}
@@ -164,7 +167,9 @@ func (e *EtcdPool) unMarshallValue(v []byte) PeerInfo {
 
 	// for backward compatible with older gubernator versions
 	if err := json.Unmarshal(v, &p); err != nil {
-		e.log.WithError(err).Errorf("while unmarshalling peer info from key value")
+		e.log.LogAttrs(context.TODO(), slog.LevelError, "while unmarshalling peer info from key value",
+			ErrAttr(err),
+		)
 		return PeerInfo{HTTPAddress: string(v)}
 	}
 	return p
@@ -181,12 +186,14 @@ func (e *EtcdPool) watch() error {
 	e.wg.Until(func(done chan struct{}) bool {
 		for response := range e.watchChan {
 			if response.Canceled {
-				e.log.Infof("graceful watch shutdown")
+				e.log.Info("graceful watch shutdown")
 				return false
 			}
 
 			if err := response.Err(); err != nil {
-				e.log.Errorf("watch error: %v", err)
+				e.log.LogAttrs(context.TODO(), slog.LevelError, "watch error",
+					ErrAttr(err),
+				)
 				goto restart
 			}
 			_ = e.collectPeers(&rev)
@@ -203,8 +210,9 @@ func (e *EtcdPool) watch() error {
 		}
 
 		if err := e.watchPeers(); err != nil {
-			e.log.WithError(err).
-				Error("while attempting to restart watch")
+			e.log.LogAttrs(context.TODO(), slog.LevelError, "while attempting to restart watch",
+				ErrAttr(err),
+			)
 			select {
 			case <-clock.After(backOffTimeout):
 				return true
@@ -220,7 +228,9 @@ func (e *EtcdPool) watch() error {
 
 func (e *EtcdPool) register(peer PeerInfo) error {
 	instanceKey := e.conf.KeyPrefix + peer.HTTPAddress
-	e.log.Infof("Registering peer '%#v' with etcd", peer)
+	e.log.LogAttrs(context.TODO(), slog.LevelInfo, "Registering peer with etcd",
+		slog.Any("peer", peer),
+	)
 
 	b, err := json.Marshal(peer)
 	if err != nil {
@@ -262,8 +272,9 @@ func (e *EtcdPool) register(peer PeerInfo) error {
 		// If we have lost our keep alive, register again
 		if keepAlive == nil {
 			if err = register(); err != nil {
-				e.log.WithError(err).
-					Error("while attempting to re-register peer")
+				e.log.LogAttrs(context.TODO(), slog.LevelError, "while attempting to re-register peer",
+					ErrAttr(err),
+				)
 				select {
 				case <-clock.After(backOffTimeout):
 					return true
@@ -297,13 +308,15 @@ func (e *EtcdPool) register(peer PeerInfo) error {
 		case <-done:
 			ctx, cancel := context.WithTimeout(context.Background(), etcdTimeout)
 			if _, err := e.conf.Client.Delete(ctx, instanceKey); err != nil {
-				e.log.WithError(err).
-					Warn("during etcd delete")
+				e.log.LogAttrs(context.TODO(), slog.LevelError, "during etcd delete",
+					ErrAttr(err),
+				)
 			}
 
 			if _, err := e.conf.Client.Revoke(ctx, lease.ID); err != nil {
-				e.log.WithError(err).
-					Warn("during lease revoke")
+				e.log.LogAttrs(context.TODO(), slog.LevelError, "during lease revoke",
+					ErrAttr(err),
+				)
 			}
 			cancel()
 			return false

--- a/flags.go
+++ b/flags.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package gubernator
 
+import (
+	"context"
+	"log/slog"
+)
+
 const (
 	FlagOSMetrics MetricFlags = 1 << iota
 	FlagGolangMetrics
@@ -50,7 +55,10 @@ func getEnvMetricFlags(log FieldLogger, name string) MetricFlags {
 		case "golang":
 			result.Set(FlagGolangMetrics, true)
 		default:
-			log.Errorf("invalid flag '%s' for '%s' valid options are ['os', 'golang']", f, name)
+			log.LogAttrs(context.TODO(), slog.LevelError, "invalid flag, valid options are ['os', 'golang']",
+				slog.String("flag", f),
+				slog.String("name", name),
+			)
 		}
 	}
 	return result

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.37.0
 	github.com/segmentio/fasthash v1.0.2
-	github.com/sirupsen/logrus v1.9.2
 	github.com/stretchr/testify v1.9.0
 	go.etcd.io/etcd/client/v3 v3.5.5
 	go.opentelemetry.io/otel v1.26.0
@@ -65,6 +64,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
+	github.com/sirupsen/logrus v1.9.2 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/uptrace/opentelemetry-go-extra/otellogrus v0.2.1 // indirect

--- a/log.go
+++ b/log.go
@@ -4,36 +4,29 @@ import (
 	"bufio"
 	"context"
 	"io"
+	"log/slog"
 	"sync"
-	"time"
-
-	"github.com/sirupsen/logrus"
 )
 
-// The FieldLogger interface generalizes the Entry and Logger types
 type FieldLogger interface {
-	WithField(key string, value interface{}) *logrus.Entry
-	WithFields(fields logrus.Fields) *logrus.Entry
-	WithError(err error) *logrus.Entry
-	WithContext(ctx context.Context) *logrus.Entry
-	WithTime(t time.Time) *logrus.Entry
+	Handler() slog.Handler
+	With(args ...any) *slog.Logger
+	WithGroup(name string) *slog.Logger
+	Enabled(ctx context.Context, level slog.Level) bool
+	Log(ctx context.Context, level slog.Level, msg string, args ...any)
+	LogAttrs(ctx context.Context, level slog.Level, msg string, attrs ...slog.Attr)
+	Debug(msg string, args ...any)
+	DebugContext(ctx context.Context, msg string, args ...any)
+	Info(msg string, args ...any)
+	InfoContext(ctx context.Context, msg string, args ...any)
+	Warn(msg string, args ...any)
+	WarnContext(ctx context.Context, msg string, args ...any)
+	Error(msg string, args ...any)
+	ErrorContext(ctx context.Context, msg string, args ...any)
+}
 
-	Tracef(format string, args ...interface{})
-	Debugf(format string, args ...interface{})
-	Infof(format string, args ...interface{})
-	Printf(format string, args ...interface{})
-	Warnf(format string, args ...interface{})
-	Warningf(format string, args ...interface{})
-	Errorf(format string, args ...interface{})
-	Fatalf(format string, args ...interface{})
-
-	Log(level logrus.Level, args ...interface{})
-	Debug(args ...interface{})
-	Info(args ...interface{})
-	Print(args ...interface{})
-	Warn(args ...interface{})
-	Warning(args ...interface{})
-	Error(args ...interface{})
+func ErrAttr(err error) slog.Attr {
+	return slog.Any("error", err)
 }
 
 type logAdaptor struct {
@@ -61,7 +54,9 @@ func newLogAdaptor(log FieldLogger) *logAdaptor {
 			log.Info(scanner.Text())
 		}
 		if err := scanner.Err(); err != nil {
-			log.Errorf("Error while reading from Writer: %s", err)
+			log.LogAttrs(context.TODO(), slog.LevelError, "Error while reading from Writer",
+				ErrAttr(err),
+			)
 		}
 		_ = reader.Close()
 		wg.Done()

--- a/logging.go
+++ b/logging.go
@@ -18,13 +18,13 @@ package gubernator
 
 import (
 	"encoding/json"
+	"log/slog"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 type LogLevelJSON struct {
-	Level logrus.Level
+	Level slog.Level
 }
 
 func (ll LogLevelJSON) MarshalJSON() ([]byte, error) {
@@ -41,9 +41,9 @@ func (ll *LogLevelJSON) UnmarshalJSON(b []byte) error {
 
 	switch value := v.(type) {
 	case float64:
-		ll.Level = logrus.Level(int32(value))
+		ll.Level = slog.Level(int32(value))
 	case string:
-		ll.Level, err = logrus.ParseLevel(value)
+		err = ll.Level.UnmarshalText([]byte(value))
 	default:
 		return errors.New("invalid log level")
 	}

--- a/tls.go
+++ b/tls.go
@@ -18,6 +18,7 @@ package gubernator
 
 import (
 	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -25,6 +26,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"log/slog"
 	"math/big"
 	"net"
 	"os"
@@ -33,7 +35,6 @@ import (
 
 	"github.com/mailgun/holster/v4/setter"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -154,7 +155,7 @@ func SetupTLS(conf *TLSConfig) error {
 		minServerTLSVersion = tls.VersionTLS13
 	}
 
-	setter.SetDefault(&conf.Logger, logrus.WithField("category", "gubernator"))
+	setter.SetDefault(&conf.Logger, slog.Default().With("category", "gubernator"))
 	conf.Logger.Info("Detected TLS Configuration")
 
 	// Basic config with reasonably secure defaults
@@ -239,7 +240,9 @@ func SetupTLS(conf *TLSConfig) error {
 	if conf.CaPEM != nil {
 		rootPool, err := x509.SystemCertPool()
 		if err != nil {
-			conf.Logger.Warnf("while loading system CA Certs '%s'; using provided pool instead", err)
+			conf.Logger.LogAttrs(context.TODO(), slog.LevelWarn, "while loading system CA Certs; using provided pool instead",
+				ErrAttr(err),
+			)
 			rootPool = x509.NewCertPool()
 		}
 		rootPool.AppendCertsFromPEM(conf.CaPEM.Bytes())
@@ -327,15 +330,16 @@ func selfCert(conf *TLSConfig) error {
 		}
 	}
 
-	conf.Logger.Info("Generating Server Private Key and Certificate....")
-	conf.Logger.Infof("Cert DNS names: (%s)", strings.Join(cert.DNSNames, ","))
-	conf.Logger.Infof("Cert IPs: (%s)", func() string {
-		var r []string
-		for i := range cert.IPAddresses {
-			r = append(r, cert.IPAddresses[i].String())
-		}
-		return strings.Join(r, ",")
-	}())
+	conf.Logger.LogAttrs(context.TODO(), slog.LevelInfo, "Generating Server Private Key and Certificate....",
+		slog.String("dns_names", strings.Join(cert.DNSNames, ",")),
+		slog.String("cert_ips", func() string {
+			var r []string
+			for i := range cert.IPAddresses {
+				r = append(r, cert.IPAddresses[i].String())
+			}
+			return strings.Join(r, ",")
+		}()),
+	)
 
 	// Generate a public / private key
 	privKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)

--- a/tls_test.go
+++ b/tls_test.go
@@ -21,16 +21,17 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"log/slog"
 	"math/rand"
 	"net/http"
 	"strings"
 	"testing"
 
-	"github.com/gubernator-io/gubernator/v3"
 	"github.com/mailgun/holster/v4/clock"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gubernator-io/gubernator/v3"
 )
 
 func spawnDaemon(t *testing.T, conf gubernator.DaemonConfig) *gubernator.Daemon {
@@ -352,7 +353,7 @@ func TestHTTPSDaemonPeerAuth(t *testing.T) {
 	} {
 		ctx, cancel := context.WithTimeout(context.Background(), clock.Second*10)
 		d, err := gubernator.SpawnDaemon(ctx, gubernator.DaemonConfig{
-			Logger:            logrus.WithField("instance", peer.HTTPAddress),
+			Logger:            slog.Default().With("instance", peer.HTTPAddress),
 			InstanceID:        peer.HTTPAddress,
 			HTTPListenAddress: peer.HTTPAddress,
 			AdvertiseAddress:  peer.HTTPAddress,


### PR DESCRIPTION
A possibly incomplete attempt to migrate the logging over to the now standard Go `slog` system.

I see one of the dependencies (holster) still using logrus, though...