### PR TITLE
daemon: hot reload tls config

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -88,9 +88,11 @@ GUBER_INSTANCE_ID=<unique-id>
 # GUBER_TLS_CA_KEY=/path/to/ca.key
 
 # Path to the server certificate. Certificate used by the server/clients for TLS connections.
+# Support hot reload on receiving the SIGHUB signal
 # GUBER_TLS_CERT=/path/to/server.pem
 
 # Path to the server private key. This is the key for the certificate. Must be unencrypted.
+# Support hot reload on receiving the SIGHUB signal
 # GUBER_TLS_KEY=/path/to/server.key
 
 # If set to `true` gubernator will generate both the CA and self-signed server certificates.
@@ -99,6 +101,7 @@ GUBER_INSTANCE_ID=<unique-id>
 # GUBER_TLS_CA_KEY. This avoids the need to distribute a new server cert for each gubernator
 # instance at the cost of distributing the CA private key. If set but no CA or TLS certs are
 # provided gubernator will generate a CA and certs needed TLS.
+# Hot reload is disabled when GUBER_TLS_AUTO set to `true`.
 # GUBER_TLS_AUTO=false
 
 # Sets the minimum TLS version. If not set, defaults to 1.3

--- a/tls.go
+++ b/tls.go
@@ -344,7 +344,8 @@ func NewKeypairReloader(logger FieldLogger, certPath, keyPath string, clientCert
 }
 
 // maybeReload reloads TLS cert and updates client certificates.
-// Client certificates are used to conenct to gubernator peers.
+// Client certificates are used to conenct to gubernator peers. Note that
+// maybeReload is triggered upon SIGHUP
 func (kpr *keypairReloader) maybeReload() error {
 	newCert, err := tls.LoadX509KeyPair(kpr.certPath, kpr.keyPath)
 	if err != nil {
@@ -355,6 +356,11 @@ func (kpr *keypairReloader) maybeReload() error {
 	kpr.cert = &newCert
 	kpr.clientCerts = []tls.Certificate{newCert}
 	return nil
+}
+
+func (kpr *keypairReloader) UpdatePath(certPath, keyPath string) {
+	kpr.certPath = certPath
+	kpr.keyPath = keyPath
 }
 
 func (kpr *keypairReloader) GetCertificateFunc() func(*tls.ClientHelloInfo) (*tls.Certificate, error) {


### PR DESCRIPTION
As I deploy gubernator with tls and need to rotate the cert/key, which are generated by some secret management tool like vault, I want the gubernator instance to reload the cert/key without being restarted.

This PR allows gubernator to hot-reload tls cert/key on receiving a `SIGHUP` signal. A `KeypairReloader` method is used to reload the cert/key and assigned to `GetCertificate`. 

Note that `clientTLS` is still statically assigned because `GetCertificate` is inapplicable to TLS client.

`example.conf` is updated.