### PR TITLE
Avoid calling Close() or Shutdown() more than once

### DIFF
--- a/workers.go
+++ b/workers.go
@@ -58,6 +58,7 @@ type WorkerPool struct {
 	hashRingStep    uint64
 	conf            *Config
 	done            chan struct{}
+	isClosed        atomic.Bool
 }
 
 type Worker struct {
@@ -155,6 +156,9 @@ func (ph *hasher) ComputeHash63(input string) uint64 {
 }
 
 func (p *WorkerPool) Close() error {
+	if !p.isClosed.CompareAndSwap(false, true) {
+		return nil
+	}
 	close(p.done)
 	return nil
 }


### PR DESCRIPTION
### Purpose
Calling `PeerClient.Shutdown()`, `V1Instance.Close()` or `WorkerPool.Close()` twice should be allowed. If the caller does call these methods twice, the methods will simply return `nil` with no further action taken.

Fixes #35 

