### PR TITLE
Fix: add missing default to the instanceID in Config

### DIFF
--- a/config.go
+++ b/config.go
@@ -145,7 +145,11 @@ func (c *Config) SetDefaults() error {
 
 	setter.SetDefault(&c.CacheSize, 50_000)
 	setter.SetDefault(&c.Workers, runtime.NumCPU())
-	setter.SetDefault(&c.Logger, logrus.New().WithField("category", "gubernator"))
+	setter.SetDefault(&c.InstanceID, GetInstanceID())
+	setter.SetDefault(&c.Logger, logrus.New().WithFields(logrus.Fields{
+		"instance": c.InstanceID,
+		"category": "gubernator",
+	}))
 
 	if c.CacheFactory == nil {
 		c.CacheFactory = func(maxSize int) Cache {

--- a/config_test.go
+++ b/config_test.go
@@ -38,4 +38,9 @@ func TestDefaultInstanceId(t *testing.T) {
 	daemonConfig, err := SetupDaemonConfig(logrus.StandardLogger(), strings.NewReader(s))
 	require.NoError(t, err)
 	require.NotEmpty(t, daemonConfig.InstanceID)
+
+	instanceConfig := Config{}
+	err = instanceConfig.SetDefaults()
+	require.NoError(t, err)
+	require.NotEmpty(t, instanceConfig.InstanceID)
 }


### PR DESCRIPTION
As a user wants to use the V1Instance config,  we need `instanceID` in the logger field. This PR defaults the `instanceID` in the `SetDefaults` of the V1Instance.