### PR TITLE
Config: add a new no-op discovery type

### DIFF
--- a/config.go
+++ b/config.go
@@ -337,7 +337,7 @@ func SetupDaemonConfig(logger *logrus.Logger, configFile io.Reader) (DaemonConfi
 	setter.SetDefault(&conf.DataCenter, os.Getenv("GUBER_DATA_CENTER"), "")
 	setter.SetDefault(&conf.MetricFlags, getEnvMetricFlags(log, "GUBER_METRIC_FLAGS"))
 
-	choices := []string{"member-list", "k8s", "etcd", "dns"}
+	choices := []string{"member-list", "k8s", "etcd", "dns", "none"}
 	setter.SetDefault(&conf.PeerDiscoveryType, os.Getenv("GUBER_PEER_DISCOVERY_TYPE"), "member-list")
 	if !slice.ContainsString(conf.PeerDiscoveryType, choices, nil) {
 		return conf, fmt.Errorf("GUBER_PEER_DISCOVERY_TYPE is invalid; choices are [%s]`", strings.Join(choices, ","))

--- a/daemon.go
+++ b/daemon.go
@@ -241,6 +241,10 @@ func (s *Daemon) Start(ctx context.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "while creating member list pool")
 		}
+	case "none":
+		// In `none` discovery mode, daemon.SetPeers must be explicitly
+		// called to add peer to the gubernator cluster
+		s.log.Warn("Discovery type is none")
 	}
 
 	// We override the default Marshaller to enable the `UseProtoNames` option.

--- a/example.conf
+++ b/example.conf
@@ -134,7 +134,7 @@ GUBER_INSTANCE_ID=<unique-id>
 ############################
 # Peer Discovery Type
 ############################
-# Which type of peer discovery gubernator will use ('member-list', 'etcd', 'k8s')
+# Which type of peer discovery gubernator will use ('member-list', 'etcd', 'k8s', `none`)
 # GUBER_PEER_DISCOVERY_TYPE=member-list
 
 


### PR DESCRIPTION
As we are using an in-house service discovery mechanism, we need to set the `GUBER_DISCOVERY_TYPE`  to something other than the existing [list](https://github.com/gubernator-io/gubernator/blob/22853694a31ba67c86a0598c90e3a8c76501a868/config.go#L340).

This PR adds a new discovery type named `embedded`  such thatit allows us to embed gubernator and manually call the method `daemon.SetPeers` to set the gubernator peers. I understood that we can bypass the configuration check by manually creating `DaemonConfig` . However, using the `SetupDaemonConfig`  is much easier and has proven to work for most settings. 

Therefore, with this PR, users can easily embed gubernator and manually set the peers.