### PR TITLE
daemon: fix condition to determin isOwner

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -156,6 +156,7 @@ func StartWith(localPeers []gubernator.PeerInfo, opts ...option) error {
 			InstanceID:        peer.GRPCAddress,
 			GRPCListenAddress: peer.GRPCAddress,
 			HTTPListenAddress: peer.HTTPAddress,
+			AdvertiseAddress:  peer.GRPCAddress,
 			DataCenter:        peer.DataCenter,
 			Behaviors: gubernator.BehaviorConfig{
 				// Suitable for testing but not production

--- a/daemon.go
+++ b/daemon.go
@@ -406,7 +406,7 @@ func (s *Daemon) SetPeers(in []PeerInfo) {
 	copy(peers, in)
 
 	for i, p := range peers {
-		if s.conf.GRPCListenAddress == p.GRPCAddress {
+		if s.conf.AdvertiseAddress == p.GRPCAddress {
 			peers[i].IsOwner = true
 		}
 	}


### PR DESCRIPTION
Based on the definition of `AdvertiseAddress` and `GRPCListenAddress`, I think here we should use `AdvertiseAddress`, which is default to `GRPCListenAddress`. However, if node is behind a NAT, we need to set `AdvertiseAddress` to a different value than `GRPCListenAddress`.