### PR TITLE
Add GitHub action for testing k8s deployment

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,61 @@
+name: E2E
+
+on:
+  pull_request:
+    branches: [ master ]
+  push:
+    branches:
+      - master
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create k8s Kind Cluster
+        id: kind
+        uses: helm/kind-action@v1
+        with:
+          version: 'v0.27.0'
+          registry: true
+          registry_name: gubernator-io
+          registry_port: 5001
+
+      - name: Build and push
+        env:
+          LOCAL_REGISTRY: ${{ steps.kind.outputs.LOCAL_REGISTRY }}
+        run: |
+          docker build . -t $LOCAL_REGISTRY/gubernator
+          docker push $LOCAL_REGISTRY/gubernator
+
+      - name: Deploy
+        run: |
+          helm install gubernator \
+            --set gubernator.image.repository=${{ steps.kind.outputs.LOCAL_REGISTRY }}/gubernator \
+            --set gubernator.serviceAccount.create=true \
+            ./contrib/charts/gubernator
+          kubectl wait --for=condition=available deployment/gubernator
+
+      - name: k8s contents
+        if: always()
+        run: |
+          echo "===="
+          kubectl get deployments
+          echo "===="
+          kubectl describe deployments
+          echo "===="
+          kubectl get pods
+          echo "===="
+          kubectl describe pods
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22.x
+
+      - name: Test
+        run: |
+          kubectl port-forward deployment/gubernator 1050 1051 &
+          GUBER_HTTP_RETRY_COUNT=60 go run ./cmd/healthcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -89,7 +89,7 @@ linters-settings:
   stylecheck:
     # Select the Go version to target.
     # Default: 1.13
-    go: "1.19"
+#    go: "1.19"
     # https://staticcheck.io/docs/options#checks
     checks: ["all"]
 
@@ -108,5 +108,5 @@ run:
   # Default: 1m
   timeout: 5m
 
-  skip-dirs:
-    - googleapis
+#  skip-dirs:
+#    - googleapis

--- a/cmd/healthcheck/main.go
+++ b/cmd/healthcheck/main.go
@@ -17,36 +17,89 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"strconv"
+	"time"
+
+	"github.com/mailgun/holster/v4/retry"
 
 	guber "github.com/gubernator-io/gubernator/v2"
 )
 
 func main() {
+	ctx := context.Background()
+
 	url := os.Getenv("GUBER_HTTP_ADDRESS")
 	if url == "" {
 		url = "localhost:1050"
 	}
-	resp, err := http.DefaultClient.Get(fmt.Sprintf("http://%s/v1/HealthCheck", url))
-	if err != nil {
-		panic(err)
-	}
-	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		panic(err)
-	}
-
-	var hc guber.HealthCheckResp
-	if err := json.Unmarshal(body, &hc); err != nil {
-		panic(err)
-	}
-	if hc.Status != "healthy" {
+	attemptsStr := os.Getenv("GUBER_HTTP_RETRY_COUNT")
+	err := check(ctx, url, attemptsStr)
+	switch {
+	case errors.Is(err, errNotHealthy):
+		fmt.Println(err)
 		os.Exit(2)
+	case err != nil:
+		fmt.Println(err)
+		os.Exit(1)
+	default:
+		fmt.Println("is healthy")
 	}
+}
+
+var errNotHealthy = errors.New("not healthy")
+
+func check(ctx context.Context, url string, attemptsStr string) (err error) {
+	attempts, err := parseAttempts(attemptsStr)
+	if err != nil {
+		return err
+	}
+
+	return retry.Until(ctx, retry.Attempts(attempts, 500*time.Millisecond), func(ctx context.Context, i int) error {
+		reqURL := fmt.Sprintf("http://%s/v1/HealthCheck", url)
+		fmt.Printf("checking %q: attempt=%d\n", reqURL, i)
+
+		resp, err := http.Get(reqURL)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		var hc guber.HealthCheckResp
+		err = json.Unmarshal(body, &hc)
+		if err != nil {
+			return err
+		}
+
+		if hc.Status != "healthy" {
+			return fmt.Errorf("%w: status=%q message=%q peer_count=%d advertise_address=%q", errNotHealthy,
+				hc.Status,
+				hc.Message,
+				hc.PeerCount,
+				hc.AdvertiseAddress,
+			)
+		}
+
+		return nil
+	})
+}
+
+func parseAttempts(attemptsStr string) (int, error) {
+	if attemptsStr == "" {
+		return 1, nil
+	}
+
+	return strconv.Atoi(attemptsStr)
 }


### PR DESCRIPTION
- Add an action that runs Gubernator in Kubernetes, and validates that it is healthy.
- Modify healthcheck command to optionally support retries (for use in this test).
- It correctly shows that the latest Gubernator release is broken on Kubernetes.
- Hoepfully this will also let you progress with Gubernator v3, as you'll have a safety net.

```
checking "http://localhost:1050/v1/HealthCheck": attempt=54
checking "http://localhost:1050/v1/HealthCheck": attempt=55
checking "http://localhost:1050/v1/HealthCheck": attempt=56
checking "http://localhost:1050/v1/HealthCheck": attempt=57
checking "http://localhost:1050/v1/HealthCheck": attempt=58
checking "http://localhost:1050/v1/HealthCheck": attempt=59
checking "http://localhost:1050/v1/HealthCheck": attempt=60
on attempt '60'; attempts exhausted: not healthy: status="unhealthy" message="this instance is not found in the peer list" peer_count=2 advertise_address=""
```