### PR TITLE
Skip "self" check in health check when AdvertiseAddr is not specified

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,8 +35,19 @@ jobs:
           helm install gubernator \
             --set gubernator.image.repository=${{ steps.kind.outputs.LOCAL_REGISTRY }}/gubernator \
             --set gubernator.serviceAccount.create=true \
+            --set gubernator.debug=true \
             ./contrib/charts/gubernator
           kubectl wait --for=condition=available deployment/gubernator
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22.x
+
+      - name: Test
+        run: |
+          kubectl port-forward deployment/gubernator 1050 1051 &
+          GUBER_HTTP_RETRY_COUNT=30 go run ./cmd/healthcheck
 
       - name: k8s contents
         if: always()
@@ -50,12 +61,7 @@ jobs:
           echo "===="
           kubectl describe pods
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.22.x
-
-      - name: Test
+      - name: k8s logs
+        if: always()
         run: |
-          kubectl port-forward deployment/gubernator 1050 1051 &
-          GUBER_HTTP_RETRY_COUNT=60 go run ./cmd/healthcheck
+          kubectl logs deployment/gubernator

--- a/config.go
+++ b/config.go
@@ -173,6 +173,33 @@ func (c *Config) SetDefaults() error {
 	return nil
 }
 
+func (c *Config) AdvertiseAddrIsSpecified() bool {
+	if c.AdvertiseAddr == "" {
+		// If there's no address
+		return false
+	}
+
+	host, _, err := net.SplitHostPort(c.AdvertiseAddr)
+	if err != nil {
+		// If it's an invalid address
+		return false
+	}
+
+	if host == "" {
+		// For IPv4 wildcard ":1051"
+		return false
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		// If we specified a DNS name "my-dns-name:1051"
+		return true
+	}
+
+	// If it's a valid IP, and an IP address is specified i.e. not "0.0.0.0:1051" or IPv6 ":::1051"
+	return !ip.IsUnspecified()
+}
+
 type PeerInfo struct {
 	// (Optional) The name of the data center this peer is in. Leave blank if not using multi data center support.
 	DataCenter string `json:"data-center"`

--- a/config_test.go
+++ b/config_test.go
@@ -44,3 +44,50 @@ func TestDefaultInstanceId(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, instanceConfig.InstanceID)
 }
+
+func TestConfig_AdvertiseAddrIsSpecified(t *testing.T) {
+	tests := []struct {
+		name          string
+		advertiseAddr string
+		want          bool
+	}{
+		{
+			name:          "DNS name",
+			advertiseAddr: "my-dns-name:1051",
+			want:          true,
+		},
+		{
+			name:          "specified IP",
+			advertiseAddr: "10.10.10.10:1051",
+			want:          true,
+		},
+		{
+			name:          "empty string",
+			advertiseAddr: "",
+			want:          false,
+		},
+		{
+			name:          "not specified IP",
+			advertiseAddr: "0.0.0.0:1051",
+			want:          false,
+		},
+		{
+			name:          "ipv4 wildcard string",
+			advertiseAddr: ":1051",
+			want:          false,
+		},
+		{
+			name:          "ipv6 wildcard string",
+			advertiseAddr: ":::1051",
+			want:          false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{
+				AdvertiseAddr: tt.advertiseAddr,
+			}
+			require.Equal(t, c.AdvertiseAddrIsSpecified(), tt.want)
+		})
+	}
+}


### PR DESCRIPTION
- In k8s, at the moment, the advertise addr is being set to `0.0.0.0:1051` by default (i.e. not "specified").
- This, of course, is not in the list of peers (as they have specified addresses like `10.0.0.1:1051`.
- There doesn't seem to be an obvious way to get a pod's own IP address from peer discovery.
- For now, only run the additional "self" check when an IP address is "specified" (i.e. is a non-empty string, has valid IP hostname, and not `0.0.0.0:1051`), so that we can get the master branch back to being healthy.