### PR TITLE
fixing helm deploy name, max age connections and add support to a affinity and tolerations

### DIFF
--- a/contrib/charts/gubernator/templates/_helpers.tpl
+++ b/contrib/charts/gubernator/templates/_helpers.tpl
@@ -114,6 +114,6 @@ HTTP Port
 {{- end }}
 {{- if .Values.gubernator.server.grpc.maxConnAgeSeconds }}
 - name: GUBER_GRPC_MAX_CONN_AGE_SEC
-  value: {{ .Values.gubernator.server.grpc.maxConnAgeSeconds }}
+  value: "{{ .Values.gubernator.server.grpc.maxConnAgeSeconds }}"
 {{- end }}
 {{- end }}

--- a/contrib/charts/gubernator/templates/deployment.yaml
+++ b/contrib/charts/gubernator/templates/deployment.yaml
@@ -32,6 +32,14 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.gubernator.affinity }}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.gubernator.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: gubernator
           env:

--- a/contrib/charts/gubernator/templates/deployment.yaml
+++ b/contrib/charts/gubernator/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: gubernator
+  name: {{ include "gubernator.fullname" . }}
   labels:
   {{- include "gubernator.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
Fixing helm deploy name, let you change the name of the deployment. It was static gubernator and now let us change this name as us like.