### PR TITLE
add support keda object, fix deployment to support different name and remove liveness and readiness probe

### DIFF
--- a/contrib/charts/gubernator/templates/_helpers.tpl
+++ b/contrib/charts/gubernator/templates/_helpers.tpl
@@ -51,7 +51,7 @@ Common labels
 {{- with .Values.gubernator.labels }}
 {{- toYaml . }}
 {{- end }}
-app: gubernator
+app: {{ include "gubernator.fullname" . }}
 helm.sh/chart: {{ include "gubernator.chart" . }}
 {{ include "gubernator.selectorLabels" . }}
 {{- if .Chart.AppVersion }}

--- a/contrib/charts/gubernator/templates/deployment.yaml
+++ b/contrib/charts/gubernator/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
         - name: gubernator
           env:
           {{- include "gubernator.env" . | nindent 10 }}
+          {{- with .Values.gubernator.extraEnv }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           image: {{ .Values.gubernator.image.repository }}:{{ .Values.gubernator.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.gubernator.image.pullPolicy }}
           ports:
@@ -51,14 +54,6 @@ spec:
               containerPort: {{ include "gubernator.grpc.port" .  }}
             - name: http
               containerPort: {{ include "gubernator.http.port" .  }}
-          livenessProbe:
-            httpGet:
-              port: {{ include "gubernator.http.port" . }}
-              path: "/v1/LiveCheck"
-          readinessProbe:
-            httpGet:
-              port: {{ include "gubernator.http.port" . }}
-              path: "/v1/HealthCheck"
           {{- with .Values.gubernator.resources }}
           resources:
           {{- toYaml . | nindent 12 }}

--- a/contrib/charts/gubernator/templates/hpa.yaml
+++ b/contrib/charts/gubernator/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gubernator.autoscaling.enabled -}}
+{{- if and (.Values.gubernator.autoscaling.enabled) (ne .Values.gubernator.autoscaling.methodScaling "keda") }}
 {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: autoscaling/v2
 {{- else -}}

--- a/contrib/charts/gubernator/templates/keda.yaml
+++ b/contrib/charts/gubernator/templates/keda.yaml
@@ -1,0 +1,55 @@
+{{- if and (.Values.gubernator.autoscaling.enabled) (eq .Values.gubernator.autoscaling.methodScaling "keda") }}
+{{- $name := include "gubernator.fullname" . -}}
+{{- $ReleaseName := .Release.Name }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  labels:
+    scaledobject.keda.sh/name: {{ $name }}
+    {{- include "gubernator.labels" . | nindent 4 }}
+  annotations:
+    {{- include "gubernator.annotations" . | nindent 4 }}
+  name: {{ $name }}
+spec:
+  scaleTargetRef:
+    apiVersion:    apps/v1
+    kind:          Deployment
+    name:          {{ $name }}
+  cooldownPeriod: {{ .Values.gubernator.autoscaling.cooldownPeriod | default 300 }}
+  maxReplicaCount: {{ .Values.gubernator.autoscaling.maxReplicas }}
+  minReplicaCount: {{ .Values.gubernator.autoscaling.minReplicas }}
+  pollingInterval: {{ .Values.gubernator.autoscaling.pollingInterval | default 15 }}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: {{ .Values.gubernator.autoscaling.downscaleForbiddenWindowSeconds }}
+          policies:
+          - type: Percent
+            value: {{ .Values.gubernator.autoscaling.behaviorScaleDownPercent | default 30 }}
+            periodSeconds: {{ .Values.gubernator.autoscaling.downscaleForbiddenWindowSeconds }}
+        scaleUp:
+          stabilizationWindowSeconds: {{ .Values.gubernator.autoscaling.upscaleForbiddenWindowSeconds }}
+          policies:
+          - type: Percent
+            value: {{ .Values.gubernator.autoscaling.behaviorScaleUpPercent | default 100 }}
+            periodSeconds: {{ .Values.gubernator.autoscaling.upscaleForbiddenWindowSeconds }}
+          - type: Pods
+            value: {{ .Values.gubernator.autoscaling.behaviorScaleUpPods | default 15 }}
+            periodSeconds: {{ .Values.gubernator.autoscaling.upscaleForbiddenWindowSeconds }}
+          selectPolicy: Max
+  triggers:
+  {{- if .Values.gubernator.autoscaling.targetCPUUtilizationPercentage }}
+  - metadata:
+      type: {{ .type |default "Utilization" }}
+      value: {{ .Values.gubernator.autoscaling.targetCPUUtilizationPercentage | quote }}
+    type: cpu
+  {{- end}}
+  {{- if .Values.gubernator.autoscaling.targetMemoryUtilizationPercentage }}
+  - metadata:
+      type: {{ .type | default "Utilization" }}
+      value: {{ .Values.gubernator.autoscaling.targetMemoryUtilizationPercentage | quote }}
+    type: memory
+  {{- end }}
+  
+  {{- end }}

--- a/contrib/charts/gubernator/values.yaml
+++ b/contrib/charts/gubernator/values.yaml
@@ -68,13 +68,3 @@ gubernator:
     create: false
     interval: 5s
     scrapeTimeout: 5s
-
-  autoscaling:
-    enabled: true
-    methodScaling: "keda"
-    minReplicas: 1
-    maxReplicas: 2
-    downscaleForbiddenWindowSeconds: 300
-    upscaleForbiddenWindowSeconds: 15
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 80

--- a/contrib/charts/gubernator/values.yaml
+++ b/contrib/charts/gubernator/values.yaml
@@ -6,9 +6,22 @@ gubernator:
 
   autoscaling:
     enabled: true
+    methodScaling: "hpa"
     minReplicas: 2
     maxReplicas: 10
     cpuAverageUtilization: 50
+
+  # keda example
+  # https://keda.sh/docs/2.16/reference/scaledobject-spec
+  # autoscaling:
+  #   enabled: true
+  #   methodScaling: "keda"
+  #   minReplicas: 1
+  #   maxReplicas: 2
+  #   downscaleForbiddenWindowSeconds: 300
+  #   upscaleForbiddenWindowSeconds: 15
+  #   targetCPUUtilizationPercentage: 80
+  #   targetMemoryUtilizationPercentage: 80
 
   replicaCount: 4
 
@@ -19,8 +32,8 @@ gubernator:
     # By default tag is overriding appVersion from .Chart.yaml
     tag: "latest"
 
-  labels:
-    a: "b"
+  # labels:
+  #   a: "b"
 
   # Enabling gubernator debugger, default false
   # debug: true
@@ -55,3 +68,13 @@ gubernator:
     create: false
     interval: 5s
     scrapeTimeout: 5s
+
+  autoscaling:
+    enabled: true
+    methodScaling: "keda"
+    minReplicas: 1
+    maxReplicas: 2
+    downscaleForbiddenWindowSeconds: 300
+    upscaleForbiddenWindowSeconds: 15
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80


### PR DESCRIPTION
This update introduces support for KEDA (Kubernetes Event-driven Autoscaling) objects, enhancing the application's scalability capabilities. Additionally, the deployment configuration has been modified to allow for customizable naming conventions, providing greater flexibility in resource management. Lastly, the liveness and readiness probes have been removed from the deployment, simplifying the health check mechanism for the application.