### PR TITLE
feat: Add Graceful Termination Delay

### DIFF
--- a/config.go
+++ b/config.go
@@ -211,6 +211,10 @@ type DaemonConfig struct {
 	// Default is infinity
 	GRPCMaxConnectionAgeSeconds int
 
+	// (Optional) Defines the delay added in seconds before the graceful termination starts.
+	// Default is 0
+	GracefulTerminationDelaySeconds int
+
 	// (Optional) The `address:port` that is advertised to other Gubernator peers.
 	// Defaults to `GRPCListenAddress`
 	AdvertiseAddress string
@@ -335,6 +339,7 @@ func SetupDaemonConfig(logger *logrus.Logger, configFile io.Reader) (DaemonConfi
 	setter.SetDefault(&conf.InstanceID, GetInstanceID())
 	setter.SetDefault(&conf.HTTPStatusListenAddress, os.Getenv("GUBER_STATUS_HTTP_ADDRESS"), "")
 	setter.SetDefault(&conf.GRPCMaxConnectionAgeSeconds, getEnvInteger(log, "GUBER_GRPC_MAX_CONN_AGE_SEC"), 0)
+	setter.SetDefault(&conf.GracefulTerminationDelaySeconds, getEnvInteger(log, "GUBER_GRACEFUL_TERMINATION_DELAY_SEC"), 0)
 	setter.SetDefault(&conf.CacheSize, getEnvInteger(log, "GUBER_CACHE_SIZE"), 50_000)
 	setter.SetDefault(&conf.Workers, getEnvInteger(log, "GUBER_WORKER_COUNT"), 0)
 	setter.SetDefault(&conf.AdvertiseAddress, os.Getenv("GUBER_ADVERTISE_ADDRESS"), conf.GRPCListenAddress)

--- a/daemon.go
+++ b/daemon.go
@@ -381,6 +381,10 @@ func (s *Daemon) Close() {
 		return
 	}
 
+	if s.conf.GracefulTerminationDelaySeconds > 0 {
+		time.Sleep(time.Duration(s.conf.GracefulTerminationDelaySeconds) * time.Second)
+	}
+
 	if s.pool != nil {
 		s.pool.Close()
 	}

--- a/example.conf
+++ b/example.conf
@@ -36,6 +36,10 @@ GUBER_INSTANCE_ID=<unique-id>
 # If value is zero (default) time is infinity
 # GUBER_GRPC_MAX_CONN_AGE_SEC=30
 
+# Defines the delay added in seconds before the graceful termination starts.
+# Default is 0
+# GUBER_GRACEFUL_TERMINATION_DELAY_SEC=20
+
 # A list of optional prometheus metric collection
 # os - collect process metrics
 #      See https://pkg.go.dev/github.com/prometheus/client_golang@v1.11.0/prometheus/collectors#NewProcessCollector


### PR DESCRIPTION
Kubernetes does not immediately remove a terminating Pod from the associated Service endpoints. This can result in in-flight requests being routed to a Pod that is already shutting down, potentially causing failed requests or degraded performance.

This change introduces a new configuration option: GracefulTerminationDelaySeconds. When set, the Daemon will sleep for the specified duration before beginning its shutdown sequence. This gives the Kubernetes endpoint controller time to update the endpoints list and stop directing traffic to the terminating Pod.

This delay improves the reliability of request handling during rolling updates, Pod evictions, and other lifecycle events, especially in latency-sensitive or stateful services.