### PR TITLE
Ensure the endpoint selector references the helm app label

### DIFF
--- a/contrib/charts/gubernator/templates/_helpers.tpl
+++ b/contrib/charts/gubernator/templates/_helpers.tpl
@@ -101,7 +101,7 @@ HTTP Port
 - name: GUBER_K8S_POD_PORT
   value: "{{ include "gubernator.grpc.port" . }}"
 - name: GUBER_K8S_ENDPOINTS_SELECTOR
-  value: "app=gubernator"
+  value: "app={{ include "gubernator.fullname" . }}"
 {{- if .Values.gubernator.debug }}
 - name: GUBER_DEBUG
   value: "true"


### PR DESCRIPTION
The `app` label can be different if the helm release name is different than just `gubernator`. If hardcoded, the release won't find any peers, but we can just pull the value of the correct app label from the helm context.