### PR TITLE
ci(release): push Helm chart to GHCR as OCI artifact

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -20,6 +20,8 @@ jobs:
   build:
     needs: vuln-check
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -58,8 +60,15 @@ jobs:
           pull: true
           push: true
 
-      # Publish the Helm chart
-#      - name: Publish Helm chart
-#        uses: stefanprodan/helm-gh-pages@v1.5.0
-#        with:
-#          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v4.1.4
+
+      - name: Push Helm chart to GHCR (OCI)
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          helm package contrib/charts/gubernator --destination ./ --version "${VERSION}"
+          helm push "gubernator-${VERSION}.tgz" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -9,6 +9,7 @@
 The `on-release` workflow handles everything else:
 - Updates the Helm chart version from the release tag.
 - Builds and pushes the Docker image for `linux/amd64` and `linux/arm64`.
+- Packages and pushes the Helm chart to GHCR as an OCI artifact (`oci://ghcr.io/gubernator-io/charts/gubernator`).
 
 ## Version Derivation
 


### PR DESCRIPTION
Add helm package/push to on-release, packages:write permission, and document the chart URL in RELEASE.md.

might honestly work ootb with a new tag

cc @abbassoltanian-usmobile sorry for the delay on this (: