### PR TITLE
fix(gubernator): preserve error from GetPeerRateLimit on retry

### DIFF
--- a/gubernator.go
+++ b/gubernator.go
@@ -365,15 +365,17 @@ func (s *V1Instance) asyncRequest(ctx context.Context, req *AsyncReq) {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				attempts++
 				metricBatchSendRetries.WithLabelValues(req.Req.Name).Inc()
-				req.Peer, err = s.GetPeer(ctx, req.Key)
-				if err != nil {
+				var peerErr error
+				req.Peer, peerErr = s.GetPeer(ctx, req.Key)
+				if peerErr != nil {
 					errPart := fmt.Sprintf("while finding peer that owns rate limit '%s'", req.Key)
-					s.log.WithContext(ctx).WithError(err).WithField("key", req.Key).Error(errPart)
-					countError(err, "during GetPeer()")
-					err = fmt.Errorf("%s: %w", errPart, err)
+					s.log.WithContext(ctx).WithError(peerErr).WithField("key", req.Key).Error(errPart)
+					countError(peerErr, "during GetPeer()")
+					err = fmt.Errorf("%s: %w", errPart, peerErr)
 					resp.Resp = &RateLimitResp{Error: err.Error()}
 					break
 				}
+				reqState.IsOwner = req.Peer.Info().IsOwner
 				continue
 			}
 

--- a/issue71_test.go
+++ b/issue71_test.go
@@ -2,6 +2,7 @@ package gubernator_test
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"strings"
 	"testing"
@@ -40,7 +41,11 @@ func TestErrorStompedOnGetPeerRetry(t *testing.T) {
 	require.NoError(t, err)
 	fakePeerSrv := grpc.NewServer()
 	guber.RegisterPeersV1Server(fakePeerSrv, &slowPeersV1Server{})
-	go fakePeerSrv.Serve(fakePeerListener)
+	go func() {
+		if err := fakePeerSrv.Serve(fakePeerListener); err != nil {
+			fmt.Printf("while serving fake peer: %s\n", err)
+		}
+	}()
 	defer fakePeerSrv.GracefulStop()
 
 	// Create a PeerClient with batching enabled and a long batch timeout.
@@ -75,11 +80,15 @@ func TestErrorStompedOnGetPeerRetry(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	defer srv.Close()
+	defer func() { _ = srv.Close() }()
 
 	mainListener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	go mainSrv.Serve(mainListener)
+	go func() {
+		if err := mainSrv.Serve(mainListener); err != nil {
+			fmt.Printf("while serving main: %s\n", err)
+		}
+	}()
 	defer mainSrv.GracefulStop()
 
 	// Call GetRateLimits directly on the V1Instance (exported method).

--- a/issue71_test.go
+++ b/issue71_test.go
@@ -1,0 +1,123 @@
+package gubernator_test
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	guber "github.com/gubernator-io/gubernator/v2"
+	"github.com/mailgun/holster/v4/clock"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+type slowPeersV1Server struct {
+	guber.UnimplementedPeersV1Server
+}
+
+func (s *slowPeersV1Server) GetPeerRateLimits(ctx context.Context, _ *guber.GetPeerRateLimitsReq) (*guber.GetPeerRateLimitsResp, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+type fixedPeerPicker struct {
+	peer *guber.PeerClient
+}
+
+func (p *fixedPeerPicker) GetByPeerInfo(guber.PeerInfo) *guber.PeerClient { return p.peer }
+func (p *fixedPeerPicker) Peers() []*guber.PeerClient                     { return []*guber.PeerClient{p.peer} }
+func (p *fixedPeerPicker) Get(string) (*guber.PeerClient, error)          { return p.peer, nil }
+func (p *fixedPeerPicker) New() guber.PeerPicker                          { return p }
+func (p *fixedPeerPicker) Add(*guber.PeerClient)                          {}
+
+func TestErrorStompedOnGetPeerRetry(t *testing.T) {
+	// Start a fake peer GRPC server that blocks until context is canceled.
+	fakePeerListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	fakePeerSrv := grpc.NewServer()
+	guber.RegisterPeersV1Server(fakePeerSrv, &slowPeersV1Server{})
+	go fakePeerSrv.Serve(fakePeerListener)
+	defer fakePeerSrv.GracefulStop()
+
+	// Create a PeerClient with batching enabled and a long batch timeout.
+	// The batch timeout (30s) must be much longer than the caller's context
+	// deadline, so the caller's context expires first. This causes
+	// getPeerRateLimitsBatch to return via ctx.Done(), producing an error
+	// where errors.Is(err, context.DeadlineExceeded) == true, which
+	// enters the retry loop in asyncRequest.
+	peer, err := guber.NewPeerClient(guber.PeerConfig{
+		Info: guber.PeerInfo{
+			GRPCAddress: fakePeerListener.Addr().String(),
+			IsOwner:     false,
+		},
+		Behavior: guber.BehaviorConfig{
+			BatchTimeout: time.Second * 30,
+			BatchWait:    time.Millisecond * 1,
+			BatchLimit:   1,
+		},
+		Log: logrus.WithField("test", "issue71"),
+	})
+	require.NoError(t, err)
+
+	picker := &fixedPeerPicker{peer: peer}
+
+	mainSrv := grpc.NewServer()
+	srv, err := guber.NewV1Instance(guber.Config{
+		GRPCServers: []*grpc.Server{mainSrv},
+		LocalPicker: picker,
+		Behaviors: guber.BehaviorConfig{
+			GlobalSyncWait: clock.Millisecond * 50,
+			GlobalTimeout:  clock.Second,
+		},
+	})
+	require.NoError(t, err)
+	defer srv.Close()
+
+	mainListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go mainSrv.Serve(mainListener)
+	defer mainSrv.GracefulStop()
+
+	// Call GetRateLimits directly on the V1Instance (exported method).
+	// Use a short context deadline so the caller's context expires during
+	// getPeerRateLimitsBatch, triggering the retry loop. Since we're calling
+	// the method directly (not through GRPC), we can observe the response
+	// even after the context expires — GetRateLimits blocks on wg.Wait()
+	// until asyncRequest completes.
+	shortCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
+	defer cancel()
+
+	createdAt := int64(0)
+	resp, err := srv.GetRateLimits(shortCtx, &guber.GetRateLimitsReq{
+		Requests: []*guber.RateLimitReq{
+			{
+				Name:      "test_error_stomp",
+				UniqueKey: "account:123",
+				Algorithm: guber.Algorithm_TOKEN_BUCKET,
+				Duration:  guber.Second,
+				Hits:      1,
+				Limit:     10,
+				CreatedAt: &createdAt,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Responses, 1)
+
+	// The response should have an error because the peer is unreachable.
+	// BUG: Due to the error stomp at gubernator.go:368, the error wraps nil,
+	// producing "...peers that are not connected for '...': <nil>" instead
+	// of containing the original context error cause.
+	errMsg := resp.Responses[0].Error
+	assert.NotEmpty(t, errMsg)
+	assert.False(t, strings.Contains(errMsg, "<nil>"),
+		"error message should not contain '<nil>' — the original context error was stomped")
+	assert.True(t,
+		strings.Contains(strings.ToLower(errMsg), "deadline exceeded") ||
+			strings.Contains(strings.ToLower(errMsg), "canceled"),
+		"error message should contain the original context error cause")
+}


### PR DESCRIPTION
### Purpose
In `asyncRequest`, when `GetPeerRateLimit` returns `context.DeadlineExceeded` or `context.Canceled`, the subsequent call to `GetPeer` unconditionally assigned its return value to the same `err` variable, stomping the non-nil error with nil when `GetPeer` succeeds. This caused misleading log messages like `error="<nil>"` after the retry loop exhausted its attempts. Additionally, `reqState.IsOwner` was never refreshed after `GetPeer` returned a new peer, preventing the local fast-path from being taken when ownership changed.

### Implementation
- Used a separate `peerErr` variable for the `GetPeer` return value so the original context error from `GetPeerRateLimit` is preserved through the retry loop
- Added `reqState.IsOwner = req.Peer.Info().IsOwner` after a successful `GetPeer` call to refresh ownership state when the peer changes on retry
- Added `TestErrorStompedOnGetPeerRetry` surface test that sets up a slow fake GRPC peer, triggers the retry loop via context deadline expiration, and asserts the error response contains the actual context error instead of `<nil>`

Fixes #71