### PR TITLE
feat: implement GregorianWeeks for DURATION_IS_GREGORIAN behavior

### DIFF
--- a/functional_test.go
+++ b/functional_test.go
@@ -843,7 +843,8 @@ func TestLeakyBucketGregorian(t *testing.T) {
 			assert.Equal(t, test.Status, rl.Status)
 			assert.Equal(t, test.Remaining, rl.Remaining)
 			assert.Equal(t, int64(60), rl.Limit)
-			assert.Greater(t, rl.ResetTime, now.Unix())
+			// ResetTime is milliseconds since epoch; it must never be in the past.
+			assert.GreaterOrEqual(t, rl.ResetTime, clock.Now().UnixMilli())
 			clock.Advance(test.Sleep)
 		})
 	}
@@ -887,7 +888,6 @@ func TestLeakyBucketGregorianWeek(t *testing.T) {
 		},
 	}
 
-	now := clock.Now()
 	name := t.Name()
 	key := guber.RandomString(10)
 
@@ -912,7 +912,8 @@ func TestLeakyBucketGregorianWeek(t *testing.T) {
 			assert.Equal(t, test.Status, rl.Status)
 			assert.Equal(t, test.Remaining, rl.Remaining)
 			assert.Equal(t, int64(60), rl.Limit)
-			assert.Greater(t, rl.ResetTime, now.Unix())
+			// ResetTime is milliseconds since epoch; it must never be in the past.
+			assert.GreaterOrEqual(t, rl.ResetTime, clock.Now().UnixMilli())
 			clock.Advance(test.Sleep)
 		})
 	}

--- a/functional_test.go
+++ b/functional_test.go
@@ -294,6 +294,75 @@ func TestTokenBucketGregorian(t *testing.T) {
 	}
 }
 
+func TestTokenBucketGregorianWeek(t *testing.T) {
+	defer clock.Freeze(clock.Now()).Unfreeze()
+
+	client, err := guber.DialV1Server(cluster.GetRandomPeer(cluster.DataCenterNone).GRPCAddress, nil)
+	require.NoError(t, err)
+
+	tests := []struct {
+		Name      string
+		Remaining int64
+		Status    guber.Status
+		Sleep     clock.Duration
+		Hits      int64
+	}{
+		{
+			Name:      "first hit",
+			Hits:      1,
+			Remaining: 59,
+			Status:    guber.Status_UNDER_LIMIT,
+		},
+		{
+			Name:      "consume remaining hits",
+			Hits:      59,
+			Remaining: 0,
+			Status:    guber.Status_UNDER_LIMIT,
+		},
+		{
+			Name:      "should be over the limit",
+			Hits:      1,
+			Remaining: 0,
+			Status:    guber.Status_OVER_LIMIT,
+			Sleep:     clock.Hour * 24 * 8,
+		},
+		{
+			Name:      "should be under the limit after week boundary",
+			Hits:      0,
+			Remaining: 60,
+			Status:    guber.Status_UNDER_LIMIT,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			resp, err := client.GetRateLimits(context.Background(), &guber.GetRateLimitsReq{
+				Requests: []*guber.RateLimitReq{
+					{
+						Name:      "test_token_bucket_greg_week",
+						UniqueKey: "account:greg_week",
+						Behavior:  guber.Behavior_DURATION_IS_GREGORIAN,
+						Algorithm: guber.Algorithm_TOKEN_BUCKET,
+						Duration:  guber.GregorianWeeks,
+						Hits:      test.Hits,
+						Limit:     60,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			rl := resp.Responses[0]
+
+			assert.Empty(t, rl.Error)
+			assert.Equal(t, test.Status, rl.Status)
+			assert.Equal(t, test.Remaining, rl.Remaining)
+			assert.Equal(t, int64(60), rl.Limit)
+			assert.True(t, rl.ResetTime != 0)
+			clock.Advance(test.Sleep)
+		})
+	}
+}
+
 func TestTokenBucketNegativeHits(t *testing.T) {
 	defer clock.Freeze(clock.Now()).Unfreeze()
 
@@ -763,6 +832,75 @@ func TestLeakyBucketGregorian(t *testing.T) {
 						Behavior:  guber.Behavior_DURATION_IS_GREGORIAN,
 						Algorithm: guber.Algorithm_LEAKY_BUCKET,
 						Duration:  guber.GregorianMinutes,
+						Hits:      test.Hits,
+						Limit:     60,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			rl := resp.Responses[0]
+			assert.Equal(t, test.Status, rl.Status)
+			assert.Equal(t, test.Remaining, rl.Remaining)
+			assert.Equal(t, int64(60), rl.Limit)
+			assert.Greater(t, rl.ResetTime, now.Unix())
+			clock.Advance(test.Sleep)
+		})
+	}
+}
+
+func TestLeakyBucketGregorianWeek(t *testing.T) {
+	defer clock.Freeze(clock.Now()).Unfreeze()
+
+	client, err := guber.DialV1Server(cluster.PeerAt(0).GRPCAddress, nil)
+	require.NoError(t, err)
+
+	// Leak rate for a week-long bucket with limit 60: 604800000ms / 60 = 10080000ms (~168 min) per token.
+	// Sleep 1: clock.Hour (60 min < 168 min) → no leak
+	// Sleep 2: clock.Hour * 3 (180 min > 168 min) → 1 token leaks: floor(10800000/10080000) = 1
+	tests := []struct {
+		Name      string
+		Hits      int64
+		Remaining int64
+		Status    guber.Status
+		Sleep     clock.Duration
+	}{
+		{
+			Name:      "first hit",
+			Hits:      1,
+			Remaining: 59,
+			Status:    guber.Status_UNDER_LIMIT,
+			Sleep:     clock.Hour,
+		},
+		{
+			Name:      "second hit; no leak",
+			Hits:      1,
+			Remaining: 58,
+			Status:    guber.Status_UNDER_LIMIT,
+			Sleep:     clock.Hour * 3,
+		},
+		{
+			Name:      "third hit; leak one hit",
+			Hits:      1,
+			Remaining: 58,
+			Status:    guber.Status_UNDER_LIMIT,
+		},
+	}
+
+	now := clock.Now()
+	name := t.Name()
+	key := guber.RandomString(10)
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			resp, err := client.GetRateLimits(context.Background(), &guber.GetRateLimitsReq{
+				Requests: []*guber.RateLimitReq{
+					{
+						Name:      name,
+						UniqueKey: key,
+						Behavior:  guber.Behavior_DURATION_IS_GREGORIAN,
+						Algorithm: guber.Algorithm_LEAKY_BUCKET,
+						Duration:  guber.GregorianWeeks,
 						Hits:      test.Hits,
 						Limit:     60,
 					},

--- a/interval.go
+++ b/interval.go
@@ -90,7 +90,7 @@ func GregorianDuration(now clock.Time, d int64) (int64, error) {
 	case GregorianDays:
 		return 8.64e+7, nil
 	case GregorianWeeks:
-		return 0, errors.New("`Duration = GregorianWeeks` not yet supported; consider making a PR!`")
+		return 604800000, nil
 	case GregorianMonths:
 		y, m, _ := now.Date()
 		// Given the beginning of the month, subtract the end of the current month to get the duration
@@ -131,7 +131,10 @@ func GregorianExpiration(now clock.Time, d int64) (int64, error) {
 		return clock.Date(y, m, d, 23, 59, 59, int(clock.Second-clock.Nanosecond), now.Location()).
 			UnixNano() / 1000000, nil
 	case GregorianWeeks:
-		return 0, errors.New("`Duration = GregorianWeeks` not yet supported; consider making a PR!`")
+		y, m, d := now.Date()
+		daysUntilSunday := (7 - int(now.Weekday())) % 7
+		return clock.Date(y, m, d+daysUntilSunday, 23, 59, 59, int(clock.Second-clock.Nanosecond), now.Location()).
+			UnixNano() / 1000000, nil
 	case GregorianMonths:
 		y, m, _ := now.Date()
 		return clock.Date(y, m, 1, 0, 0, 0, 0, now.Location()).

--- a/interval_test.go
+++ b/interval_test.go
@@ -89,6 +89,38 @@ func TestGregorianExpirationDay(t *testing.T) {
 	assert.Equal(t, int64(1573516799999), expire)
 }
 
+func TestGregorianExpirationWeek(t *testing.T) {
+	// November 13, 2019 is a Wednesday; verify assumption
+	now := clock.Date(2019, clock.November, 13, 00, 00, 00, 00, clock.UTC)
+	require.Equal(t, clock.Wednesday, now.Weekday())
+
+	// Wednesday should expire at end of Sunday November 17, 2019
+	expire, err := gubernator.GregorianExpiration(now, gubernator.GregorianWeeks)
+	require.NoError(t, err)
+	assert.Equal(t, clock.Date(2019, clock.November, 17, 23, 59, 59, 999000000, clock.UTC),
+		clock.Unix(0, expire*1000000).UTC())
+
+	// Expect the same expire time regardless of time-of-day within the same week
+	now = clock.Date(2019, clock.November, 13, 12, 10, 9, 2345, clock.UTC)
+	expire, err = gubernator.GregorianExpiration(now, gubernator.GregorianWeeks)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1574035199999), expire)
+
+	// Sunday itself should expire at end of that same Sunday (not next Sunday)
+	now = clock.Date(2019, clock.November, 17, 10, 00, 00, 00, clock.UTC)
+	expire, err = gubernator.GregorianExpiration(now, gubernator.GregorianWeeks)
+	require.NoError(t, err)
+	assert.Equal(t, clock.Date(2019, clock.November, 17, 23, 59, 59, 999000000, clock.UTC),
+		clock.Unix(0, expire*1000000).UTC())
+
+	// Monday should expire at end of the following Sunday (November 24)
+	now = clock.Date(2019, clock.November, 18, 00, 00, 00, 00, clock.UTC)
+	expire, err = gubernator.GregorianExpiration(now, gubernator.GregorianWeeks)
+	require.NoError(t, err)
+	assert.Equal(t, clock.Date(2019, clock.November, 24, 23, 59, 59, 999000000, clock.UTC),
+		clock.Unix(0, expire*1000000).UTC())
+}
+
 func TestGregorianExpirationMonth(t *testing.T) {
 	// Validate calculation assumption
 	now := clock.Date(2019, clock.November, 1, 00, 00, 00, 00, clock.UTC)


### PR DESCRIPTION
### Purpose

Implements `GregorianWeeks` support for the `DURATION_IS_GREGORIAN` behavior, closing #75. Rate limits using `Duration: GregorianWeeks` now reset at ISO 8601 week boundaries (end of Sunday, 23:59:59.999). The `GregorianWeeks` constant and proto documentation already existed but both `GregorianDuration()` and `GregorianExpiration()` returned "not yet supported" errors.

### Implementation

- **`interval.go`**: `GregorianDuration()` now returns `604800000` (7 days in ms) for `GregorianWeeks`. `GregorianExpiration()` computes end-of-week by calculating days until Sunday via `(7 - int(now.Weekday())) % 7` and returning Sunday 23:59:59.999 as Unix milliseconds, following the existing pattern used by other Gregorian intervals.
- **`interval_test.go`**: Added `TestGregorianExpirationWeek` covering mid-week Wednesday, idempotency within the same week, Sunday edge case (expires same Sunday, not next), and Monday rollover to the following Sunday.
- **`functional_test.go`**: Added `TestTokenBucketGregorianWeek` (verifies token bucket reset after week boundary via 8-day clock advance) and `TestLeakyBucketGregorianWeek` (verifies leak rate of ~168 minutes per token for a 60-limit weekly bucket).

Closes #75