### PR TITLE
fix: prevent nil pointer panic in SpawnDaemon on pool startup failure

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -224,10 +224,11 @@ func (s *Daemon) Start(ctx context.Context) error {
 	case "k8s":
 		// Source our list of peers from kubernetes endpoint API
 		s.conf.K8PoolConf.OnUpdate = s.V1Server.SetPeers
-		s.pool, err = NewK8sPool(s.conf.K8PoolConf)
-		if err != nil {
-			return errors.Wrap(err, "while querying kubernetes API")
+		k8sPool, k8sErr := NewK8sPool(s.conf.K8PoolConf)
+		if k8sErr != nil {
+			return errors.Wrap(k8sErr, "while querying kubernetes API")
 		}
+		s.pool = k8sPool
 	case "etcd":
 		s.conf.EtcdPoolConf.OnUpdate = s.V1Server.SetPeers
 		// Register ourselves with other peers via ETCD
@@ -236,25 +237,28 @@ func (s *Daemon) Start(ctx context.Context) error {
 			return errors.Wrap(err, "while connecting to etcd")
 		}
 
-		s.pool, err = NewEtcdPool(s.conf.EtcdPoolConf)
-		if err != nil {
-			return errors.Wrap(err, "while creating etcd pool")
+		etcdPool, etcdErr := NewEtcdPool(s.conf.EtcdPoolConf)
+		if etcdErr != nil {
+			return errors.Wrap(etcdErr, "while creating etcd pool")
 		}
+		s.pool = etcdPool
 	case "dns":
 		s.conf.DNSPoolConf.OnUpdate = s.V1Server.SetPeers
-		s.pool, err = NewDNSPool(s.conf.DNSPoolConf)
-		if err != nil {
-			return errors.Wrap(err, "while creating the DNS pool")
+		dnsPool, dnsErr := NewDNSPool(s.conf.DNSPoolConf)
+		if dnsErr != nil {
+			return errors.Wrap(dnsErr, "while creating the DNS pool")
 		}
+		s.pool = dnsPool
 	case "member-list":
 		s.conf.MemberListPoolConf.OnUpdate = s.V1Server.SetPeers
 		s.conf.MemberListPoolConf.Logger = s.log
 
 		// Register peer on the member list
-		s.pool, err = NewMemberListPool(ctx, s.conf.MemberListPoolConf)
-		if err != nil {
-			return errors.Wrap(err, "while creating member list pool")
+		mlPool, mlErr := NewMemberListPool(ctx, s.conf.MemberListPoolConf)
+		if mlErr != nil {
+			return errors.Wrap(mlErr, "while creating member list pool")
 		}
+		s.pool = mlPool
 	case "none":
 		// In `none` discovery mode, daemon.SetPeers must be explicitly
 		// called to add peer to the gubernator cluster

--- a/etcd.go
+++ b/etcd.go
@@ -90,7 +90,11 @@ func NewEtcdPool(conf EtcdPoolConfig) (*EtcdPool, error) {
 		conf:      conf,
 		ctx:       ctx,
 	}
-	return pool, pool.run(conf.Advertise)
+	if err := pool.run(conf.Advertise); err != nil {
+		pool.cancelCtx()
+		return nil, err
+	}
+	return pool, nil
 }
 
 func (e *EtcdPool) run(peer PeerInfo) error {
@@ -315,6 +319,9 @@ func (e *EtcdPool) register(peer PeerInfo) error {
 }
 
 func (e *EtcdPool) Close() {
+	if e == nil {
+		return
+	}
 	e.cancelCtx()
 	e.wg.Stop()
 }

--- a/etcd_internal_test.go
+++ b/etcd_internal_test.go
@@ -20,7 +20,7 @@ func TestNewEtcdPoolRunFailureReturnsNil(t *testing.T) {
 	if !assert.NoError(t, err, "etcd.New should not fail before any dial attempt") {
 		t.Skip("could not create etcd client; skipping")
 	}
-	client.Close()
+	require.NoError(t, client.Close())
 
 	pool, err := NewEtcdPool(EtcdPoolConfig{
 		Advertise: PeerInfo{GRPCAddress: "localhost:1051"},

--- a/etcd_internal_test.go
+++ b/etcd_internal_test.go
@@ -1,0 +1,31 @@
+package gubernator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	etcd "go.etcd.io/etcd/client/v3"
+)
+
+// TestNewEtcdPoolRunFailureReturnsNil ensures that NewEtcdPool returns a nil *EtcdPool when
+// run() fails, so callers that assign the result to a PoolInterface cannot end up with a
+// non-nil interface wrapping a nil pointer (which would panic on Close).
+func TestNewEtcdPoolRunFailureReturnsNil(t *testing.T) {
+	// Create a real client then close it immediately so register() fails fast
+	// without waiting for a network timeout.
+	client, err := etcd.New(etcd.Config{
+		Endpoints: []string{"localhost:1"},
+	})
+	if !assert.NoError(t, err, "etcd.New should not fail before any dial attempt") {
+		t.Skip("could not create etcd client; skipping")
+	}
+	client.Close()
+
+	pool, err := NewEtcdPool(EtcdPoolConfig{
+		Advertise: PeerInfo{GRPCAddress: "localhost:1051"},
+		Client:    client,
+	})
+	require.Error(t, err)
+	assert.Nil(t, pool, "NewEtcdPool must return nil on error to avoid typed-nil-in-interface panic")
+}

--- a/functional_test.go
+++ b/functional_test.go
@@ -2612,3 +2612,26 @@ func TestAsyncRequestPreservesContextError(t *testing.T) {
 		assert.NotNil(t, entry.Data["error"])
 	}
 }
+
+// TestSpawnDaemon_K8sStartupFailure_NoPanic is a regression test for issue #101.
+// When the Kubernetes API is unreachable, SpawnDaemon must return an error rather than
+// panicking with a nil pointer dereference in (*K8sPool).Close().
+func TestSpawnDaemon_K8sStartupFailure_NoPanic(t *testing.T) {
+	// Ensure we're not inside a real cluster so RestConfig() fails.
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := guber.SpawnDaemon(ctx, guber.DaemonConfig{
+		GRPCListenAddress:  "localhost:0",
+		HTTPListenAddress:  "localhost:0",
+		PeerDiscoveryType:  "k8s",
+		K8PoolConf: guber.K8sPoolConfig{
+			Namespace: "default",
+			Mechanism: guber.WatchEndpointSlices,
+		},
+	})
+	require.Error(t, err, "SpawnDaemon must return an error when k8s API is unreachable")
+}

--- a/functional_test.go
+++ b/functional_test.go
@@ -2625,9 +2625,9 @@ func TestSpawnDaemon_K8sStartupFailure_NoPanic(t *testing.T) {
 	defer cancel()
 
 	_, err := guber.SpawnDaemon(ctx, guber.DaemonConfig{
-		GRPCListenAddress:  "localhost:0",
-		HTTPListenAddress:  "localhost:0",
-		PeerDiscoveryType:  "k8s",
+		GRPCListenAddress: "localhost:0",
+		HTTPListenAddress: "localhost:0",
+		PeerDiscoveryType: "k8s",
 		K8PoolConf: guber.K8sPoolConfig{
 			Namespace: "default",
 			Mechanism: guber.WatchEndpointSlices,

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -99,7 +99,11 @@ func NewK8sPool(conf K8sPoolConfig) (*K8sPool, error) {
 	}
 	setter.SetDefault(&pool.log, logrus.WithField("category", "gubernator"))
 
-	return pool, pool.start()
+	if err := pool.start(); err != nil {
+		pool.watchCancel()
+		return nil, err
+	}
+	return pool, nil
 }
 
 func (e *K8sPool) start() error {
@@ -313,6 +317,9 @@ func ExtractPeersFromEndpointSlices(slices []*discoveryv1.EndpointSlice, podIP, 
 }
 
 func (e *K8sPool) Close() {
+	if e == nil {
+		return
+	}
 	e.watchCancel()
 	close(e.done)
 }

--- a/kubernetes_internal_test.go
+++ b/kubernetes_internal_test.go
@@ -10,6 +10,24 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// TestNewK8sPoolStartFailureReturnsNil ensures that NewK8sPool returns a nil *K8sPool when
+// start() fails, so callers that assign the result to a PoolInterface cannot end up with a
+// non-nil interface wrapping a nil pointer (which would panic on Close).
+func TestNewK8sPoolStartFailureReturnsNil(t *testing.T) {
+	// Unset in-cluster env vars so RestConfig() fails deterministically.
+	// t.Setenv with "" is equivalent to Unsetenv for InClusterConfig (checks len > 0).
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+	t.Setenv("KUBECONFIG", "")
+
+	pool, err := NewK8sPool(K8sPoolConfig{
+		Namespace: "default",
+		Mechanism: WatchEndpointSlices,
+	})
+	require.Error(t, err)
+	assert.Nil(t, pool, "NewK8sPool must return nil on error to avoid typed-nil-in-interface panic")
+}
+
 func TestWatchMechanismFromString(t *testing.T) {
 	for _, test := range []struct {
 		input    string


### PR DESCRIPTION
## Summary

Fixes #101 — `SpawnDaemon` panics with a nil pointer dereference in `(*K8sPool).Close()` when the Kubernetes API is unreachable at startup.

### Root cause

Two bugs interact:

1. `NewK8sPool` (and `NewEtcdPool`) used `return pool, pool.start()`.
   When `start()` fails, a non-nil `*K8sPool` is returned alongside the
   error — violating the constructor invariant.

2. `daemon.Start` assigned the result directly to the `PoolInterface`
   field:
```go
   s.pool, err = NewK8sPool(...)
```

In Go, storing a typed-nil pointer in an interface produces a non-nil interface value (it carries type metadata). So the guard if s.pool != nil in Daemon.Close() passes, and s.pool.Close() dispatches to a nil receiver — panic.

Latent before v2.14.0; exposed when that release added s.Close() on startup error for resource cleanup.

Fix (three layers)

Constructors (kubernetes.go, etcd.go) — return nil, err on failure. Also call the context cancel function before returning to avoid leaking the allocated context.WithCancel.

Assignment sites (daemon.go) — all four pool cases now use a typed local variable and assign to s.pool only on success. This is the decisive defensive fix: even a future constructor that violates the invariant cannot produce a typed nil in the interface field.

Nil-receiver guards (kubernetes.go, etcd.go) — K8sPool.Close() and EtcdPool.Close() both gain if e == nil { return } as a last-resort backstop.

Test plan

- [x] go test -v -race -run TestSpawnDaemon_K8sStartupFailure_NoPanic ./... — must not panic
- [x] go test -v -race -run "TestNewK8sPool|TestNewEtcdPool" ./... — must pass
- [x] make test — no regressions (pre-existing DNS test failures are unrelated)
- [x] make lint — clean