### PR TITLE
fix: bump pytest to 9.0.3 to resolve Dependabot alert

### DIFF
--- a/python/requirements-py3.txt
+++ b/python/requirements-py3.txt
@@ -1,11 +1,5 @@
-atomicwrites==1.3.0
-attrs==18.2.0
 googleapis-common-protos==1.66.0
 grpcio==1.68.1
 grpcio-tools==1.68.1
-more-itertools==6.0.0
-pluggy==0.8.1
 protobuf==5.29.6
-py==1.10.0
-pytest==7.2.0
-six==1.12.0
+pytest==9.0.3


### PR DESCRIPTION
### Purpose
Dependabot flagged the last remaining open security alert on the repo: **GHSA-6w46-j5rx-g56g** ("pytest has vulnerable tmpdir handling", medium) against \`pytest==7.2.0\` in \`python/requirements-py3.txt\`. Older pytest created its \`tmp_path\`/\`tmpdir\` fixtures in a predictable, world-accessible directory that a local user could pre-create or symlink.

This bumps pytest to the patched **9.0.3**, closing the alert. The Python tests are developer/manual only (not wired into any CI workflow or the Makefile), so exposure was already minimal — this simply keeps the dependency clean.

All other Dependabot alerts on the repo (protobuf, otel/sdk, otlptracehttp) are already in the \`fixed\` state; this was the only one still open.

### Implementation
- \`python/requirements-py3.txt\`: \`pytest==7.2.0\` → \`pytest==9.0.3\`.
- Removed stale pins that were only transitive dependencies of pytest 7 and are no longer required by pytest 9: \`atomicwrites\`, \`attrs\`, \`more-itertools\`, \`pluggy\` (old \`0.8.1\`), and \`py\`. \`six\` was also removed — a grep of \`python/gubernator/\` confirms none of these are imported by the client code.
- Verified \`pytest==9.0.3\` installs cleanly and runs the module-scoped fixture pattern used by \`python/tests/test_client.py\`.