### PR TITLE
fix: make the go-bench gate warn only instead of failing the build

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -76,8 +76,11 @@ jobs:
           external-data-json-path: ./cache/benchmark-data.json
           # Do not save the data
           save-data-file: false
-          # Workflow will fail when an alert happens
-          fail-on-alert: true
+          # Warn only. `make bench` takes one sample per benchmark, and this step compares
+          # that single sample against a single cached sample from master. On a shared
+          # runner that cannot tell a real regression from scheduler noise, so alerts are
+          # reported in the job summary but no longer fail the build. See ENG-164.
+          fail-on-alert: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Enable Job Summary for PRs
           summary-always: true


### PR DESCRIPTION
### Purpose

The `go-bench` gate fails PRs on noise rather than real regressions, which sends maintainers CI failure emails for changes that cannot affect performance.

PR #107 failed this gate twice on the same commit against the same cached master baseline, flagging a different set of benchmarks each time:

- Run 1: `BenchmarkLRUCache/Concurrent_writes` 1847 -> 3734 ns/op (2.02x). Reads passed.
- Run 2, same commit: `Concurrent_reads` 1355 -> 7559 ns/op (5.58x) and `Concurrent_reads_and_writes_of_existing_keys` 2394 -> 11623 ns/op (4.86x). Writes passed.

That diff only bumped otel, x/text and grpc-gateway. `lrucache.go` imports `container/list`, `sync/atomic`, holster `clock`/`setter`, and prometheus — none of which changed. An interleaved local A/B of the two dependency sets over 8 rounds measured geomean +0.01%, with five of six benchmarks statistically indistinguishable under benchstat.

`make bench` takes one sample per benchmark, and this step compares that single sample against a single cached sample from master with a 200% threshold. On a shared runner that cannot separate a regression from scheduler jitter on mutex-contention benchmarks.

After this change benchmarks still run and flagged results still appear in the job summary. They no longer block a merge.

### Implementation

- `.github/workflows/on-pull-request.yml`, "Compare benchmarks with master" step: `fail-on-alert` from `true` to `false`. This is the only step that ever set it; the second `github-action-benchmark` step, which runs when there is no cached master baseline, is unchanged.

Raising the sample count was built, measured, and rejected. `benchmark-action/github-action-benchmark` has no reduction step: `extractGoResult` emits one entry per output line with no grouping, and `findAlerts` compares every entry against whichever baseline line matched first. N samples therefore give N independent chances to trip the threshold instead of one averaged comparison, and `make bench` went from 3m49s to ~21m24s locally at `-count=6`. Restoring a blocking gate needs median reduction before the file reaches the action.

Fixes ENG-164
